### PR TITLE
ApiSdk: Extended the response returned by the ApiSession to return Ap…

### DIFF
--- a/python/avi/sdk/test/test_api.cfg
+++ b/python/avi/sdk/test/test_api.cfg
@@ -1,6 +1,6 @@
 {
 	"LoginInfo": {
-		"controller_ip": "10.10.24.64",
+		"controller_ip": "10.10.25.42",
 		"username": "admin",
 		"password": "avi123",
 		"tenant": "admin"

--- a/python/setup.py
+++ b/python/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
-AVI_PIP_VERSION = '16.1'
+AVI_PIP_VERSION = 'master'
 if os.path.exists("./VERSION"):
     with open("./VERSION", "r") as f:
         fs = yaml.load(f.read())


### PR DESCRIPTION
…iResponse which provides a convenience function obj() that can be used to directly get object dictionary in all good cases. In case, response was HTTP 404 then it throws exception ObjNotFound. In all other error scenarios it throws Exception APIError
