### PR TITLE
The following are applicable for this changeset:

### DIFF
--- a/python/avi/sdk/avi_api.py
+++ b/python/avi/sdk/avi_api.py
@@ -112,7 +112,7 @@ class ApiSession(Session):
     SESSION_CACHE_EXPIRY = 20*60
 
     def __init__(self, controller_ip, username, password=None, token=None,
-                 tenant=None, tenant_uuid=None, verify=False):
+                 tenant=None, tenant_uuid=None, verify=False, port=None):
         """
         initialize new session object with authenticated token from login api.
         It also keeps a cache of user sessions that are cleaned up if inactive
@@ -129,14 +129,16 @@ class ApiSession(Session):
         self.prefix = (controller_ip if controller_ip.startswith('http')
                        else "https://%s" % controller_ip)
         self.verify = verify
+        self.port = port
+        self.key = controller_ip + username
 
         try:
-            user_session = ApiSession.sessionDict[username]["api"]
+            user_session = ApiSession.sessionDict[self.key]["api"]
         except KeyError:
-            logger.debug("Session does not exist creating new session for %s",
-                         username)
+            logger.debug("Session does not exist; Creating new session for %s",
+                         self.key)
             self.authenticate_session()
-            ApiSession.sessionDict[username] = \
+            ApiSession.sessionDict[self.key] = \
                 {"api": self, "last_used": datetime.utcnow()}
             user_session = self
         self.headers = copy.deepcopy(user_session.headers)
@@ -152,7 +154,7 @@ class ApiSession(Session):
 
     @staticmethod
     def get_session(controller_ip, username, password=None, token=None,
-                    tenant=None, tenant_uuid=None, verify=False):
+                    tenant=None, tenant_uuid=None, verify=False, port=None):
         """
         returns the session object for same user and tenant
         calls init if session dose not exist and adds it to session cache
@@ -162,20 +164,25 @@ class ApiSession(Session):
         :param token: Token to use; example, a valid keystone token
         :param tenant: Name of the tenant on Avi Controller
         :param tenant_uuid: Don't specify tenant when using tenant_id
+        :param port: Rest-API may use a different port other than 443
         """
+        key = controller_ip + username
         try:
-            user_session = ApiSession.sessionDict[username]["api"]
+            user_session = ApiSession.sessionDict[key]["api"]
             if user_session.password != password:
+                logger.debug('Password mismatch; Clean cached session %s', key)
+                del ApiSession.sessionDict[key]
                 raise APIError("Authentication Failed")
             if user_session.tenant != tenant:
                 raise APIError("Tenant doesn't match; use ApiSessionAdapter")
         except KeyError:
-            logger.debug("Session does not exist creating new session for %s",
-                         username)
+            logger.debug("Session does not exist; Creating new session for %s",
+                         key)
             user_session = ApiSession(controller_ip, username, password,
                                       token=token, tenant=tenant,
-                                      tenant_uuid=tenant_uuid, verify=verify)
-            ApiSession.sessionDict[user_session.username] = \
+                                      tenant_uuid=tenant_uuid, verify=verify,
+                                      port=port)
+            ApiSession.sessionDict[self.key] = \
                 {"api": user_session, "last_used": datetime.utcnow()}
         ApiSession._clean_inactive_sessions()
         return user_session
@@ -185,7 +192,7 @@ class ApiSession(Session):
         resets and re-authenticates the current session.
         :param api: ApiSession object
         """
-        logger.info('resetting session for %s', self.username)
+        logger.info('resetting session for %s', self.key)
         self.headers = {}
         self.authenticate_session()
 
@@ -214,9 +221,9 @@ class ApiSession(Session):
         if rsp.cookies and 'csrftoken' in rsp.cookies:
             csrftoken = rsp.cookies['csrftoken']
             self.headers.update({"X-CSRFToken": csrftoken})
-            if self.username in ApiSession.sessionDict:
+            if self.key in ApiSession.sessionDict:
                 cached_api = \
-                    ApiSession.sessionDict[self.username]['api']
+                    ApiSession.sessionDict[key]['api']
                 cached_api.headers.update({"X-CSRFToken": csrftoken})
         logger.debug("authentication success for user %s with headers: %s",
                      self.username, self.headers)
@@ -508,11 +515,20 @@ class ApiSession(Session):
             return None
 
     def _get_api_path(self, path, uuid=None):
-        """returns the full url from relative path and uuid"""
-        if uuid:
-            return self.prefix+'/api/'+path+'/'+uuid
+        """
+        This function returns the full url from relative path and uuid.
+        If there is a configured port (ex: Rest API port may be something
+        other than 443), then it is included in the path.
+        """
+        if self.port is not None:
+            prefix = '{x}:{y}'.format(x=self.prefix, y=self.port)
         else:
-            return self.prefix+'/api/'+path
+            prefix = self.prefix
+
+        if uuid:
+            return prefix+'/api/'+path+'/'+uuid
+        else:
+            return prefix+'/api/'+path
 
     def _get_uuid_by_name(self, path, name, tenant, tenant_uuid):
         """gets object by name and service path and returns uuid"""
@@ -522,11 +538,11 @@ class ApiSession(Session):
         return self.get_obj_uuid(resp)
 
     def _update_session_last_used(self):
-        if self.username in ApiSession.sessionDict:
-            ApiSession.sessionDict[self.username]["last_used"] = \
+        if self.key in ApiSession.sessionDict:
+            ApiSession.sessionDict[self.key]["last_used"] = \
                 datetime.utcnow()
         else:
-            ApiSession.sessionDict[self.username] = \
+            ApiSession.sessionDict[self.key] = \
                 {'api': self, 'last_used': datetime.utcnow()}
 
     @staticmethod
@@ -535,9 +551,19 @@ class ApiSession(Session):
         session_cache = ApiSession.sessionDict
         logger.debug("cleaning inactive sessions in pid %d num elem %d",
                      os.getpid(), len(session_cache))
-        for user, session in session_cache.iteritems():
+        for key, session in session_cache.iteritems():
             tdiff = avi_timedelta(session["last_used"] - datetime.utcnow())
             if tdiff < ApiSession.SESSION_CACHE_EXPIRY:
                 continue
-            logger.debug("Removed session for : %s", user)
-            del session_cache[user]
+            logger.debug("Removed session for : %s", key)
+            del session_cache[key]
+
+    def delete_session(self):
+        """ Removes the session for cleanup"""
+        logger.debug("Removed session for : %s", self.key)
+        try:
+            ApiSession.sessionDict[self.key]
+        except KeyError:
+            logger.debug("Key not present: %s", self.key)
+        return
+# End of file

--- a/python/avi/sdk/avi_api.py
+++ b/python/avi/sdk/avi_api.py
@@ -182,7 +182,7 @@ class ApiSession(Session):
                                       token=token, tenant=tenant,
                                       tenant_uuid=tenant_uuid, verify=verify,
                                       port=port)
-            ApiSession.sessionDict[self.key] = \
+            ApiSession.sessionDict[key] = \
                 {"api": user_session, "last_used": datetime.utcnow()}
         ApiSession._clean_inactive_sessions()
         return user_session

--- a/python/avi/sdk/avi_api.py
+++ b/python/avi/sdk/avi_api.py
@@ -1,8 +1,7 @@
+import os
 import copy
 import json
-import os
 import logging
-import os
 from datetime import datetime, timedelta
 from requests import Response
 from requests.sessions import Session
@@ -130,7 +129,7 @@ class ApiSession(Session):
                        else "https://%s" % controller_ip)
         self.verify = verify
         self.port = port
-        self.key = controller_ip + username
+        self.key = controller_ip + ":" +  username
 
         try:
             user_session = ApiSession.sessionDict[self.key]["api"]
@@ -166,7 +165,7 @@ class ApiSession(Session):
         :param tenant_uuid: Don't specify tenant when using tenant_id
         :param port: Rest-API may use a different port other than 443
         """
-        key = controller_ip + username
+        key = controller_ip + ":" + username
         try:
             user_session = ApiSession.sessionDict[key]["api"]
             if user_session.password != password:
@@ -223,7 +222,7 @@ class ApiSession(Session):
             self.headers.update({"X-CSRFToken": csrftoken})
             if self.key in ApiSession.sessionDict:
                 cached_api = \
-                    ApiSession.sessionDict[key]['api']
+                    ApiSession.sessionDict[self.key]['api']
                 cached_api.headers.update({"X-CSRFToken": csrftoken})
         logger.debug("authentication success for user %s with headers: %s",
                      self.username, self.headers)
@@ -562,7 +561,7 @@ class ApiSession(Session):
         """ Removes the session for cleanup"""
         logger.debug("Removed session for : %s", self.key)
         try:
-            ApiSession.sessionDict[self.key]
+            ApiSession.sessionDict.pop(self.key)
         except KeyError:
             logger.debug("Key not present: %s", self.key)
         return

--- a/python/avi/sdk/avi_api.py
+++ b/python/avi/sdk/avi_api.py
@@ -560,9 +560,6 @@ class ApiSession(Session):
     def delete_session(self):
         """ Removes the session for cleanup"""
         logger.debug("Removed session for : %s", self.key)
-        try:
-            ApiSession.sessionDict.pop(self.key)
-        except KeyError:
-            logger.debug("Key not present: %s", self.key)
+        ApiSession.sessionDict.pop(self.key, None)
         return
 # End of file

--- a/python/avi/sdk/test/test_api.cfg
+++ b/python/avi/sdk/test/test_api.cfg
@@ -1,6 +1,6 @@
 {
 	"LoginInfo": {
-		"controller_ip": "10.10.25.42",
+		"controller_ip": "10.10.24.22",
 		"username": "admin",
 		"password": "avi123",
 		"tenant": "admin"

--- a/python/avi/sdk/test/test_avi_api.py
+++ b/python/avi/sdk/test/test_avi_api.py
@@ -44,11 +44,13 @@ def create_sessions(args):
     login_info, num_sessions = args
     log.info('pid %d num_sessions %d', os.getpid(), num_sessions)
     user = login_info.get("username", "admin")
+    cip = login_info.get("controller_ip")
+    key = cip + ":" + user
     for _ in xrange(num_sessions):
         api = ApiSession(login_info["controller_ip"],
                          login_info.get("username", "admin"),
                          login_info.get("password", "avi123"))
-    return 1 if user in ApiSession.sessionDict else 0
+    return 1 if key in ApiSession.sessionDict else 0
 
 
 def shared_session_check(index):
@@ -245,9 +247,9 @@ class Test(unittest.TestCase):
     def test_cleanup_sessions(self):
         ApiSession.sessionDict = {}
         api._update_session_last_used()
-        assert api.username in ApiSession.sessionDict
-        assert 'api' in ApiSession.sessionDict[api.username]
-        assert 'last_used' in ApiSession.sessionDict[api.username]
+        assert api.key in ApiSession.sessionDict
+        assert 'api' in ApiSession.sessionDict[api.key]
+        assert 'last_used' in ApiSession.sessionDict[api.key]
 
     
     def test_avi_timedelta(self):


### PR DESCRIPTION
1. Rest-apis can use a different port other than the standard ports.
   Introduced keyword port=None to get_session and ApiSession init
   functions.
2. Rewired the get_full_path api to include the port-number in the
   path when 'port' is not none.  Otherwise, use the prefix.
3. When multiple sessions with the same username BUT different IP
   addresses are used, the library was only keying on the username.
   To enhance the library to setup sessions to different controllers
   with the same username, introduced a new key mechanism:
   key = controller_ip + username.
   
   Note: no impact from external API perspective.  The dict key is
   'controller_ip + username' instead of just username.
4. Introduced 'delete_session' to remove the cached entry irrespective
   of the activity-timer.  This api is useful in the credentials change
   context, where we have to clear the cached entry.
5. Whenever authentication fails, do a clear of the cached entry.
