### PR TITLE
Changes Include:

### DIFF
--- a/python/avi/migrationtools/netscaler_converter/lbvs_converter.py
+++ b/python/avi/migrationtools/netscaler_converter/lbvs_converter.py
@@ -345,8 +345,7 @@ class LbvsConverter(object):
                     tmp_avi_config['VirtualService'].append(vs_obj)
                     # Marked redirect url as status indirect
                     ns_util.add_conv_status(lb_vs['line_no'], cmd, key,
-                                            full_cmd,
-                                            STATUS_INDIRECT, vs_obj)
+                                            full_cmd, STATUS_INDIRECT, vs_obj)
                 else:
                     # Verify that this lb vs has share the same VIP of another
                     # vs If yes then skipped this lb vs
@@ -368,8 +367,7 @@ class LbvsConverter(object):
                         self.lbvs_indirect_list,
                         ignore_for_val=self.lbvs_ignore_vals)
                     ns_util.add_conv_status(lb_vs['line_no'], cmd, key,
-                                            full_cmd,
-                                            conv_status, vs_obj)
+                                            full_cmd, conv_status, vs_obj)
                 if enable_ssl:
                     ssl_mappings = ns_config.get('bind ssl vserver', {})
                     ssl_bindings = ssl_mappings.get(key, [])

--- a/python/avi/migrationtools/netscaler_converter/lbvs_converter.py
+++ b/python/avi/migrationtools/netscaler_converter/lbvs_converter.py
@@ -343,6 +343,10 @@ class LbvsConverter(object):
                 if redirect_url:
                     avi_config['VirtualService'].append(vs_obj)
                     tmp_avi_config['VirtualService'].append(vs_obj)
+                    # Marked redirect url as status indirect
+                    ns_util.add_conv_status(lb_vs['line_no'], cmd, key,
+                                            full_cmd,
+                                            STATUS_INDIRECT, vs_obj)
                 else:
                     # Verify that this lb vs has share the same VIP of another
                     # vs If yes then skipped this lb vs
@@ -358,14 +362,14 @@ class LbvsConverter(object):
                                                skipped_status)
                         continue
                     avi_config['VirtualService'].append(vs_obj)
-                # Add summery of this lb vs in CSV/report
-                conv_status = ns_util.get_conv_status(
-                    lb_vs, self.lbvs_skip_attrs, self.lbvs_na_attrs,\
-                    self.lbvs_indirect_list,
-                    ignore_for_val=self.lbvs_ignore_vals)
-                ns_util.add_conv_status(lb_vs['line_no'], cmd, key, full_cmd,
-                                        conv_status, vs_obj)
-
+                    # Add summery of this lb vs in CSV/report
+                    conv_status = ns_util.get_conv_status(
+                        lb_vs, self.lbvs_skip_attrs, self.lbvs_na_attrs,
+                        self.lbvs_indirect_list,
+                        ignore_for_val=self.lbvs_ignore_vals)
+                    ns_util.add_conv_status(lb_vs['line_no'], cmd, key,
+                                            full_cmd,
+                                            conv_status, vs_obj)
                 if enable_ssl:
                     ssl_mappings = ns_config.get('bind ssl vserver', {})
                     ssl_bindings = ssl_mappings.get(key, [])


### PR DESCRIPTION
Previously netscaler command having redirect rule or IP address 0.0.0.0 we converted that into backend pool group or http policy set and marked status in csv as successful. This was the reason we got incorrect virtual service count for full migration. Now we marked status for that command as indirect and fixed issue.