### PR TITLE
expose RestRequest to return http.Response

### DIFF
--- a/go/examples/test/delete_configuration_test.go
+++ b/go/examples/test/delete_configuration_test.go
@@ -55,5 +55,9 @@ func TestDeleteConfigurations(t *testing.T) {
 
 	// Delete cloud
 	cloudRes := aviClient1.Cloud.DeleteByName("Test-vcenter-cloud")
-	fmt.Printf("\n Cloud deleted successfully : %-v", cloudRes)
+	fmt.Printf("\n Cloud Test-vcenter-cloud deleted successfully : %-v", cloudRes)
+
+	// Delete cloud
+	cloudRes2 := aviClient1.Cloud.DeleteByName("Test-vcenter-cloud2")
+	fmt.Printf("\n Cloud Test-vcenter-cloud2 deleted successfully : %-v", cloudRes2)
 }

--- a/go/examples/test/rest_request_test.go
+++ b/go/examples/test/rest_request_test.go
@@ -1,0 +1,53 @@
+package test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/avinetworks/sdk/go/clients"
+	"github.com/avinetworks/sdk/go/session"
+)
+
+func TestRestRequest(t *testing.T) {
+	var err error
+	aviClient, err := clients.NewAviClient(os.Getenv("controller"), "admin",
+		session.SetPassword(os.Getenv("password")),
+		session.SetTenant("admin"),
+		session.SetVersion(os.Getenv("version")))
+	if err != nil {
+		t.Log("Couldn't create session: ", err)
+		t.Fail()
+	}
+
+	var payload interface{}
+	payloadJSON := `{"name": "Test-vcenter-cloud2"}`
+	if err = json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+		t.Logf("Unable to decode payload: %v", err)
+	}
+
+	// check 404 for wrong url
+	url := "api/cloudhablas"
+	resp, err := aviClient.AviSession.RestRequest("POST", url, payload, "admin", nil)
+	aviError, _ := err.(session.AviError)
+	if resp.StatusCode != 404 && resp.StatusCode == aviError.HttpStatusCode {
+		t.Logf("Expecting HTTP 404 but got status: %d", resp.StatusCode)
+		t.Fail()
+	}
+
+	// check POST for correct URL
+	url = "api/cloud"
+	resp, err = aviClient.AviSession.RestRequest("POST", url, payload, "admin", nil)
+	if resp.StatusCode != 200 {
+		t.Logf("Expecting HTTP 200 but got status: %d", resp.StatusCode)
+		t.Fail()
+	}
+
+	// check GET
+	resp, err = aviClient.AviSession.RestRequest("GET", url, nil, "admin", nil)
+	if resp.StatusCode != 200 {
+		t.Logf("Expecting HTTP 200 but got status: %d", resp.StatusCode)
+		t.Fail()
+	}
+	return
+}

--- a/go/session/avisession.go
+++ b/go/session/avisession.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/golang/glog"
 	"io"
 	"io/ioutil"
 	"math"
@@ -18,6 +17,8 @@ import (
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/golang/glog"
 )
 
 type AviResult struct {
@@ -131,7 +132,7 @@ type AviSession struct {
 const DEFAULT_AVI_VERSION = "17.1.2"
 const DEFAULT_API_TIMEOUT = time.Duration(60 * time.Second)
 const DEFAULT_API_TENANT = "admin"
-const DEFAULT_MAX_API_RETRIES  = 3
+const DEFAULT_MAX_API_RETRIES = 3
 const DEFAULT_API_RETRY_INTERVAL = 500
 
 //NewAviSession initiates a session to AviController and returns it
@@ -457,11 +458,18 @@ func (avisess *AviSession) collectCookiesFromResp(resp *http.Response) {
 	}
 }
 
+// RestRequest exports restRequest from the SDK
+// Returns http.Response for accessing the whole http Response struct including headers and response body
+func (avisess *AviSession) RestRequest(verb string, uri string, payload interface{}, tenant string, lastError error,
+	retryNum ...int) (*http.Response, error) {
+	return avisess.restRequest(verb, uri, payload, tenant, nil)
+}
+
 // restRequest makes a REST request to the Avi Controller's REST API.
-// Returns a byte[] if successful
+// Returns http.Response if successful
+// Note: The caller of the function is responsible for doing resp.Body.Close()
 func (avisess *AviSession) restRequest(verb string, uri string, payload interface{}, tenant string, lastError error,
-	retryNum ...int) ([]byte, error) {
-	var result []byte
+	retryNum ...int) (*http.Response, error) {
 	url := avisess.prefix + uri
 
 	// If optional retryNum arg is provided, then count which retry number this is
@@ -481,14 +489,14 @@ func (avisess *AviSession) restRequest(verb string, uri string, payload interfac
 	if payload != nil {
 		jsonStr, err := json.Marshal(payload)
 		if err != nil {
-			return result, AviError{Verb: verb, Url: url, err: err}
+			return nil, AviError{Verb: verb, Url: url, err: err}
 		}
 		payloadIO = bytes.NewBuffer(jsonStr)
 	}
 
 	req, errorResult := avisess.newAviRequest(verb, url, payloadIO, tenant)
 	if errorResult.err != nil {
-		return result, errorResult
+		return nil, errorResult
 	}
 
 	retryReq := false
@@ -501,7 +509,7 @@ func (avisess *AviSession) restRequest(verb string, uri string, payload interfac
 			errorResult.err = fmt.Errorf("client.Do uri %v failed: %v", uri, err)
 			dump, err := httputil.DumpRequestOut(req, true)
 			debug(dump, err)
-			return result, errorResult
+			return nil, errorResult
 		}
 	}
 
@@ -534,7 +542,14 @@ func (avisess *AviSession) restRequest(verb string, uri string, payload interfac
 		return avisess.restRequest(verb, uri, payload, tenant, errorResult, retry+1)
 	}
 
+	return resp, nil
+}
+
+// fetchBody fetches the response body from the http.Response returned from restRequest
+func (avisess *AviSession) fetchBody(verb, uri string, resp *http.Response) (result []byte, err error) {
 	defer resp.Body.Close()
+	url := avisess.prefix + uri
+	errorResult := AviError{HttpStatusCode: resp.StatusCode, Verb: verb, Url: url}
 
 	if resp.StatusCode == 204 {
 		// no content in the response
@@ -778,7 +793,7 @@ func convertAviResponseToMapInterface(resbytes []byte) (interface{}, error) {
 type AviCollectionResult struct {
 	Count   int
 	Results json.RawMessage
-	Next	string
+	Next    string
 }
 
 func debug(data []byte, err error) {
@@ -830,10 +845,16 @@ func (avisess *AviSession) restRequestInterfaceResponse(verb string, url string,
 	if len(opts.params) != 0 {
 		url = updateUri(url, opts)
 	}
-	res, rerror := avisess.restRequest(verb, url, payload, opts.tenant, nil)
+	httpResponse, rerror := avisess.restRequest(verb, url, payload, opts.tenant, nil)
 	if rerror != nil {
 		return rerror
 	}
+
+	var res []byte
+	if res, err = avisess.fetchBody(verb, url, httpResponse); err != nil {
+		return err
+	}
+
 	if len(res) == 0 {
 		return nil
 	} else {
@@ -887,10 +908,16 @@ func (avisess *AviSession) GetCollectionRaw(uri string, options ...ApiOptionsPar
 	if len(opts.params) != 0 {
 		uri = updateUri(uri, opts)
 	}
-	res, rerror := avisess.restRequest("GET", uri, nil, opts.tenant, nil)
-	if rerror != nil || res == nil {
+	httpResponse, rerror := avisess.restRequest("GET", uri, nil, opts.tenant, nil)
+	if rerror != nil || httpResponse == nil {
 		return result, rerror
 	}
+
+	var res []byte
+	if res, err = avisess.fetchBody("GET", uri, httpResponse); err != nil {
+		return result, err
+	}
+
 	if strings.Contains(uri, "cluster?") {
 		result.Results = res
 		result.Count = 1
@@ -913,12 +940,22 @@ func (avisess *AviSession) GetCollection(uri string, objList interface{}, option
 
 // GetRaw performs a GET API call and returns raw data
 func (avisess *AviSession) GetRaw(uri string) ([]byte, error) {
-	return avisess.restRequest("GET", uri, nil, "", nil)
+	resp, rerror := avisess.restRequest("GET", uri, nil, "", nil)
+	if rerror != nil || resp == nil {
+		return nil, rerror
+	}
+
+	return avisess.fetchBody("GET", uri, resp)
 }
 
 // PostRaw performs a POST API call and returns raw data
 func (avisess *AviSession) PostRaw(uri string, payload interface{}) ([]byte, error) {
-	return avisess.restRequest("POST", uri, payload, "", nil)
+	resp, rerror := avisess.restRequest("POST", uri, nil, "", nil)
+	if rerror != nil || resp == nil {
+		return nil, rerror
+	}
+
+	return avisess.fetchBody("POST", uri, resp)
 }
 
 // GetMultipartRaw performs a GET API call and returns multipart raw data (File Download)


### PR DESCRIPTION
The exposed RestRequest provides a way to return the whole http response (including headers), and not just the response body. This is mostly required by avi_api_proxy and other clients that would need to read headers returned by AVI api server. Currently there seems to be no way to fetch the http response in the go SDK, whereas the python SDK provides the same functionality.
This function does not change the existing restRequest implementation.
cc: @grastogi23 