### PR TITLE
AV-88850: Provide more GO SDK client controls

### DIFF
--- a/go/session/avisession.go
+++ b/go/session/avisession.go
@@ -127,9 +127,9 @@ type AviSession struct {
 	// optional api retry interval in milliseconds
 	api_retry_interval int
 
-	// Number of retries the SDK should attempt when controller is not reachable.
+	// Number of retries the SDK should attempt to check controller status.
 	ctrlStatusCheckRetryCount int
-	// Total number of seconds to wait before attemptemptin another try to reach to controller.
+	// Time interval in seconds within each retry to check controller status.
 	ctrlStatusCheckRetryInterval int
 }
 

--- a/go/session/avisession.go
+++ b/go/session/avisession.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"mime/multipart"
 	"net/http"
 	"net/http/httputil"
@@ -851,9 +852,7 @@ func (avisess *AviSession) CheckControllerStatus() (bool, error) {
 		// if controller status check interval is not set during client init, use the default SDK
 		// behaviour.
 		if avisess.ctrlStatusCheckRetryInterval == 0 {
-			// Default controller status check behaviour is 10 iterations at interval of 30 secs each.
-			// i.e total 5 mins.
-			time.Sleep(time.Duration(30) * time.Second)
+			time.Sleep(getMinTimeDuration((time.Duration(math.Exp(float64(round))*3) * time.Second), (time.Duration(30) * time.Second)))
 		} else {
 			// controller status will be polled at intervals specified during client init.
 			time.Sleep(time.Duration(avisess.ctrlStatusCheckRetryInterval) * time.Second)
@@ -861,6 +860,14 @@ func (avisess *AviSession) CheckControllerStatus() (bool, error) {
 		glog.Errorf("CheckControllerStatus Controller %v Retrying. round %v..!", url, round)
 	}
 	return isControllerUp, nil
+}
+
+//getMinTimeDuration returns the minimum time duration between two time values.
+func getMinTimeDuration(durationFirst, durationSecond time.Duration) time.Duration {
+	if durationFirst <= durationSecond {
+		return durationFirst
+	}
+	return durationSecond
 }
 
 func (avisess *AviSession) restRequestInterfaceResponse(verb string, url string,

--- a/go/session/avisession.go
+++ b/go/session/avisession.go
@@ -127,6 +127,10 @@ type AviSession struct {
 
 	// optional api retry interval in milliseconds
 	api_retry_interval int
+
+	// flag to check if on API failure, the controller status should be polled by
+	// sleeping for exponentially increasing time per interation or not.
+	allowInfiniteCtrlStatusCheck bool
 }
 
 const DEFAULT_AVI_VERSION = "17.1.2"
@@ -134,6 +138,7 @@ const DEFAULT_API_TIMEOUT = time.Duration(60 * time.Second)
 const DEFAULT_API_TENANT = "admin"
 const DEFAULT_MAX_API_RETRIES = 3
 const DEFAULT_API_RETRY_INTERVAL = 500
+const DEFAULT_NON_EXPON_STAT_INTERVAL = time.Duration(30 * time.Second)
 
 //NewAviSession initiates a session to AviController and returns it
 func NewAviSession(host string, username string, options ...func(*AviSession) error) (*AviSession, error) {
@@ -149,6 +154,9 @@ func NewAviSession(host string, username string, options ...func(*AviSession) er
 	avisess.prefix = "https://" + avisess.host + "/"
 	avisess.tenant = ""
 	avisess.insecure = false
+	// This was the default behavior before providing the flexibility to configure session.
+	// This can be over-ridden while client init.
+	avisess.allowInfiniteCtrlStatusCheck = true
 
 	for _, option := range options {
 		err := option(avisess)
@@ -324,6 +332,13 @@ func (avisess *AviSession) setTenant(tenant string) error {
 // SetInsecure - Use this for NewAviSession option argument for allowing insecure connection to AviController
 func SetInsecure(avisess *AviSession) error {
 	avisess.insecure = true
+	return nil
+}
+
+// SetQuickControllerStatusCheck informs the SDK to not to poll for the controller status
+// by sleeping exponentially on every polling iteration during API failure.
+func SetQuickControllerStatusCheck(avisess *AviSession) error {
+	avisess.allowInfiniteCtrlStatusCheck = false
 	return nil
 }
 
@@ -533,7 +548,7 @@ func (avisess *AviSession) restRequest(verb string, uri string, payload interfac
 		}
 	}
 	if retryReq {
-		check, err := avisess.CheckControllerStatus()
+		check, err := avisess.CheckControllerStatus(avisess.allowInfiniteCtrlStatusCheck)
 		if check == false {
 			glog.Errorf("restRequest Error during checking controller state %v", err)
 			return nil, err
@@ -668,7 +683,7 @@ func (avisess *AviSession) restMultipartUploadRequest(verb string, uri string, f
 	}
 
 	if retryReq {
-		check, err := avisess.CheckControllerStatus()
+		check, err := avisess.CheckControllerStatus(avisess.allowInfiniteCtrlStatusCheck)
 		if check == false {
 			glog.Errorf("restMultipartUploadRequest Error during checking controller state")
 			return err
@@ -747,7 +762,7 @@ func (avisess *AviSession) restMultipartDownloadRequest(verb string, uri string,
 	}
 
 	if retryReq {
-		check, err := avisess.CheckControllerStatus()
+		check, err := avisess.CheckControllerStatus(avisess.allowInfiniteCtrlStatusCheck)
 		if check == false {
 			glog.Errorf("restMultipartDownloadRequest Error during checking controller state")
 			return err
@@ -805,11 +820,10 @@ func debug(data []byte, err error) {
 }
 
 //Checking for controller up state.
-//This is an infinite loop till the controller is in up state.
-//Return true when controller is in up state.
-func (avisess *AviSession) CheckControllerStatus() (bool, error) {
+// Flexible to wait on controller status infinitely or for fixed time span.
+func (avisess *AviSession) CheckControllerStatus(checkForCtrlStatusInfinitely bool) (bool, error) {
 	url := avisess.prefix + "/api/cluster/status"
-	//This is an infinite loop. Generating http request for a login URI till controller is in up state.
+	var isControllerUp bool
 	for round := 0; round < 10; round++ {
 		checkReq, err := http.NewRequest("GET", url, nil)
 		if err != nil {
@@ -821,6 +835,7 @@ func (avisess *AviSession) CheckControllerStatus() (bool, error) {
 			defer stateResp.Body.Close()
 			//Checking controller response
 			if stateResp.StatusCode != 503 && stateResp.StatusCode != 502 && stateResp.StatusCode != 500 {
+				isControllerUp = true
 				break
 			} else {
 				glog.Infof("CheckControllerStatus Error while generating http request %d %v",
@@ -830,10 +845,15 @@ func (avisess *AviSession) CheckControllerStatus() (bool, error) {
 			glog.Errorf("CheckControllerStatus Error while generating http request %v %v", url, err)
 		}
 		//wait before retry
-		time.Sleep(time.Duration(math.Exp(float64(round))*3) * time.Second)
+		if checkForCtrlStatusInfinitely {
+			time.Sleep(time.Duration(math.Exp(float64(round))*3) * time.Second)
+		} else {
+			// this will poll for controller status for maximum 5 minutes ( 30 secs * 10 ).
+			time.Sleep(DEFAULT_NON_EXPON_STAT_INTERVAL)
+		}
 		glog.Errorf("CheckControllerStatus Controller %v Retrying. round %v..!", url, round)
 	}
-	return true, nil
+	return isControllerUp, nil
 }
 
 func (avisess *AviSession) restRequestInterfaceResponse(verb string, url string,
@@ -950,7 +970,7 @@ func (avisess *AviSession) GetRaw(uri string) ([]byte, error) {
 
 // PostRaw performs a POST API call and returns raw data
 func (avisess *AviSession) PostRaw(uri string, payload interface{}) ([]byte, error) {
-        resp, rerror := avisess.restRequest("POST", uri, payload, "", nil)
+	resp, rerror := avisess.restRequest("POST", uri, payload, "", nil)
 	if rerror != nil || resp == nil {
 		return nil, rerror
 	}

--- a/go/session/avisession_test.go
+++ b/go/session/avisession_test.go
@@ -154,6 +154,21 @@ func testControllerStatusCheckLimits(t *testing.T) {
 	var aviSession *AviSession
 	var numRetries = 4
 	var numTimeIntervalSecs = 10
+
+	// try to init the session with illegal inputs for controller status check limits.
+	if AVI_PASSWORD != "" {
+		aviSession, err = NewAviSession(AVI_CONTROLLER, AVI_USERNAME,
+			SetTenant(AVI_TENANT), SetPassword(AVI_PASSWORD), SetInsecure, SetLazyAuthentication(true),
+			SetControllerStatusCheckLimits(0, -1), SetVersion(aviVersion))
+	} else {
+		aviSession, err = NewAviSession(AVI_CONTROLLER, AVI_USERNAME,
+			SetTenant(AVI_TENANT), SetAuthToken(AVI_AUTH_TOKEN), SetInsecure, SetLazyAuthentication(true),
+			SetControllerStatusCheckLimits(-2, -3),
+			SetVersion(aviVersion))
+	}
+	if err == nil {
+		t.Errorf("The Avi session go created with illegal arguments")
+	}
 	if AVI_PASSWORD != "" {
 		aviSession, err = NewAviSession(AVI_CONTROLLER, AVI_USERNAME,
 			SetTenant(AVI_TENANT), SetPassword(AVI_PASSWORD), SetInsecure, SetLazyAuthentication(true),
@@ -167,9 +182,6 @@ func testControllerStatusCheckLimits(t *testing.T) {
 
 	if err != nil {
 		t.Errorf("Session Creation failed: %s", err)
-	}
-	if aviSession.infinitelyCheckCtrlStatus != false {
-		t.Errorf("Failed to initialise the AVI session with limited controller status poll")
 	}
 	if aviSession.ctrlStatusCheckRetryCount != numRetries {
 		t.Errorf("Failed to initialise the AVI session with expected retry count")


### PR DESCRIPTION
**Current Behaviour of SDK to poll controller status:**
     Total 10 iterations, where each for iteration the sleep time increases exponentially with formula ```math.Exp(float64(num_iteration))*3``` . 
**New Behaviour**:
     During client init, the number of retries and the time interval between each retry can be set.
    ```aviClient, err := clients.NewAviClient("10.10.25.25", "admin",
		session.SetPassword("something"),
		session.SetTenant("admin"),
                SetControllerStatusCheckLimits(5, 10), // numRetries, Time interval in each retry.
		session.SetInsecure)```
     If SetControllerStatusCheckLimits(xx,yy) is not used, the default behaviour of retrying for 10 times over the span of 5 mins will be invoked.
