### PR TITLE
Make CheckControllerStatus optional

### DIFF
--- a/go/session/avisession.go
+++ b/go/session/avisession.go
@@ -258,6 +258,9 @@ type AviSession struct {
 	ctrlStatusCheckRetryCount int
 	// Time interval in seconds within each retry to check controller status.
 	ctrlStatusCheckRetryInterval int
+
+	// this flag disables the checkcontrollerstatus method, instead client do their own retries
+	checkCtrlStatusDisabled bool
 }
 
 const DEFAULT_AVI_VERSION = "17.1.2"
@@ -473,6 +476,13 @@ func SetControllerStatusCheckLimits(numRetries, retryInterval int) func(*AviSess
 	}
 }
 
+func ControllerStatusCheckDisabled() func(*AviSession) error {
+	return func(avisess *AviSession) error {
+		avisess.checkCtrlStatusDisabled = true
+		return nil
+	}
+}
+
 // SetTransport - Use this for NewAviSession option argument for configuring http transport to enable connection
 func SetTransport(transport *http.Transport) func(*AviSession) error {
 	return func(sess *AviSession) error {
@@ -678,17 +688,27 @@ func (avisess *AviSession) restRequest(verb string, uri string, payload interfac
 		}
 	}
 	if retryReq {
-		check, httpResp, err := avisess.CheckControllerStatus()
-		if check == false {
-			resp.Body.Close()
-			glog.Errorf("restRequest Error during checking controller state %v", err)
-			return httpResp, err
+		if !avisess.checkCtrlStatusDisabled {
+			check, httpResp, err := avisess.CheckControllerStatus()
+			if check == false {
+				resp.Body.Close()
+				glog.Errorf("restRequest Error during checking controller state %v", err)
+				return httpResp, err
+			}
+			if err := avisess.initiateSession(); err != nil {
+				resp.Body.Close()
+				return nil, err
+			}
+			return avisess.restRequest(verb, uri, payload, tenant, errorResult, retry+1)
+		} else {
+			glog.Error("Error while client.Do, CheckControllerStatus disabled, not going to retry")
+			if err != nil {
+				return nil, err
+			} else {
+				glog.Error("Rest error, returning to caller")
+				return nil, errors.New("Rest request error, returning to caller")
+			}
 		}
-		if err := avisess.initiateSession(); err != nil {
-			resp.Body.Close()
-			return nil, err
-		}
-		return avisess.restRequest(verb, uri, payload, tenant, errorResult, retry+1)
 	}
 	return resp, nil
 }
@@ -1019,7 +1039,7 @@ func (avisess *AviSession) restRequestInterfaceResponse(verb string, url string,
 		url = updateUri(url, opts)
 	}
 	httpResponse, rerror := avisess.restRequest(verb, url, payload, opts.tenant, nil)
-	if rerror != nil {
+	if rerror != nil || httpResponse == nil {
 		return rerror
 	}
 	var res []byte

--- a/go/session/avisession.go
+++ b/go/session/avisession.go
@@ -260,7 +260,7 @@ type AviSession struct {
 	ctrlStatusCheckRetryInterval int
 
 	// this flag disables the checkcontrollerstatus method, instead client do their own retries
-	checkCtrlStatusDisabled bool
+	ctrlStatusCheckDisabled bool
 }
 
 const DEFAULT_AVI_VERSION = "17.1.2"
@@ -476,11 +476,9 @@ func SetControllerStatusCheckLimits(numRetries, retryInterval int) func(*AviSess
 	}
 }
 
-func ControllerStatusCheckDisabled() func(*AviSession) error {
-	return func(avisess *AviSession) error {
-		avisess.checkCtrlStatusDisabled = true
-		return nil
-	}
+func SetNoControllerStatusCheck(avisess *AviSession) error {
+	avisess.ctrlStatusCheckDisabled = true
+	return nil
 }
 
 // SetTransport - Use this for NewAviSession option argument for configuring http transport to enable connection
@@ -660,11 +658,11 @@ func (avisess *AviSession) restRequest(verb string, uri string, payload interfac
 	if err != nil {
 		// retry until controller status check limits.
 		glog.Errorf("Client error for URI: %+v. Error: %+v", uri, err.Error())
-		dump, err := httputil.DumpRequestOut(req, true)
-		if err != nil {
+		dump, dumpErr := httputil.DumpRequestOut(req, true)
+		if dumpErr != nil {
 			glog.Error("Error while dumping request. Still retrying.")
 		}
-		debug(dump, err)
+		debug(dump, dumpErr)
 		retryReq = true
 	}
 
@@ -688,11 +686,11 @@ func (avisess *AviSession) restRequest(verb string, uri string, payload interfac
 		}
 	}
 	if retryReq {
-		if !avisess.checkCtrlStatusDisabled {
+		if !avisess.ctrlStatusCheckDisabled {
 			check, httpResp, err := avisess.CheckControllerStatus()
 			if check == false {
 				resp.Body.Close()
-				glog.Errorf("restRequest Error during checking controller state %v", err)
+				glog.Errorf("restRequest Error during checking controller state. Error: %s", err.Error())
 				return httpResp, err
 			}
 			if err := avisess.initiateSession(); err != nil {
@@ -701,13 +699,12 @@ func (avisess *AviSession) restRequest(verb string, uri string, payload interfac
 			}
 			return avisess.restRequest(verb, uri, payload, tenant, errorResult, retry+1)
 		} else {
-			glog.Error("Error while client.Do, CheckControllerStatus disabled, not going to retry")
+			glog.Error("CheckControllerStatus is disabled for this session, not going to retry.")
 			if err != nil {
-				return nil, err
-			} else {
-				glog.Error("Rest error, returning to caller")
-				return nil, errors.New("Rest request error, returning to caller")
+				glog.Errorf("Failed to invoke API. Error: %s", err.Error())
 			}
+			return nil, errors.New("Rest request error, returning to caller")
+
 		}
 	}
 	return resp, nil
@@ -1039,7 +1036,7 @@ func (avisess *AviSession) restRequestInterfaceResponse(verb string, url string,
 		url = updateUri(url, opts)
 	}
 	httpResponse, rerror := avisess.restRequest(verb, url, payload, opts.tenant, nil)
-	if rerror != nil || httpResponse == nil {
+	if rerror != nil {
 		return rerror
 	}
 	var res []byte


### PR DESCRIPTION
This commit makes the CheckControllerStatus method optional and allows
clients to opt out from using it.

If the clients don't use this method, the SDK would return back
immediately post a REST API failure to the controller and instead
expect the clients to take care of retries.

Signed-off-by: Hemant K Shaw (hkshaw@vmware.com)