### PR TITLE
AV-99104 Adding some sleep before creating session with TLS because c…

### DIFF
--- a/go/examples/test/custom_transport_test.go
+++ b/go/examples/test/custom_transport_test.go
@@ -133,6 +133,7 @@ func TestCustomTransport(t *testing.T) {
 		}
 
 	//Try to create the new session with TLS(without InsecureSkipVerify=true)
+	time.Sleep(30 * time.Second)
 	aviClientTLS, err := clients.NewAviClient(os.Getenv("AVI_CONTROLLER"), os.Getenv("AVI_USERNAME"),
 		session.SetPassword(os.Getenv("AVI_PASSWORD")),
 		session.SetTenant(os.Getenv("AVI_TENANT")),


### PR DESCRIPTION
…ontroller takes some time to reflect the systemconfiguration portal cert changes