### PR TITLE
AV-103494: Support the multi part file upload for WAF Application Provider Object in SDK

### DIFF
--- a/go/examples/test/fileupload_test.go
+++ b/go/examples/test/fileupload_test.go
@@ -73,3 +73,34 @@ func TestFileObjectUpload(t *testing.T) {
 	fileObjectRes := aviClient.FileObject.DeleteByName("TestHsmPackage")
 	fmt.Println("FileObject Deleted Successfully, : ", fileObjectRes)
 }
+
+func TestWafAppSignatureUpload(t *testing.T) {
+	aviClient, err := clients.NewAviClient(os.Getenv("AVI_CONTROLLER"), os.Getenv("AVI_USERNAME"),
+		session.SetPassword(os.Getenv("AVI_PASSWORD")),
+		session.SetTenant(os.Getenv("AVI_TENANT")),
+		session.SetVersion(os.Getenv("AVI_VERSION")),
+		session.SetInsecure)
+
+	if err != nil {
+		fmt.Println("Couldn't create session: ", err)
+		t.Fail()
+	}
+
+	local_file := "/mnt/files/rulesets/vmware-waf-rulesets-1610418004000.zip"
+	appSignData, err := aviClient.WafApplicationSignatureProvider.GetAll()
+	if err != nil {
+		log.Printf("[ERROR] MultipartWafApplicationUUpload Error uploading file %v %v", local_file, err)
+		t.Fail()
+	}
+	log.Printf(" Using the UUID: %#v", *appSignData[0].UUID)
+	uri := *appSignData[0].UUID + "/update"
+	local_file_ptr := mustOpen(local_file)
+	fileParams := make(map[string]string)
+
+	err = aviClient.AviSession.PostMultipartWafAppSignatureObjectRequest(local_file_ptr, uri, "admin", fileParams)
+	if err != nil {
+		log.Printf("[ERROR] MultipartWafApplicationUUpload Error uploading file %v %v", local_file, err)
+		t.Fail()
+	}
+	fmt.Println("\nSuccessfully set Waf applications signatures")
+}

--- a/go/session/avisession.go
+++ b/go/session/avisession.go
@@ -52,17 +52,23 @@ type AviError struct {
 }
 
 // PostMultipartRequest performs a POST API call and uploads multipart data to API fileobject/upload
+func (avisess *AviSession) PostMultipartWafAppSignatureObjectRequest(fileLocPtr *os.File, uri string, tenant string, fileParams map[string]string) error {
+	url := avisess.prefix + "/api/wafapplicationsignatureprovider/" + uri
+	return avisess.restMultipartFileObjectUploadRequest("POST", fileLocPtr, url, nil, 0, tenant, fileParams)
+}
+
+// PostMultipartRequest performs a POST API call and uploads multipart data to API fileobject/upload
 func (avisess *AviSession) PostMultipartFileObjectRequest(fileLocPtr *os.File, tenant string, fileParams map[string]string) error {
 
-	return avisess.restMultipartFileObjectUploadRequest("POST", fileLocPtr, nil, 0, tenant, fileParams)
+	url := avisess.prefix + "/api/fileobject/upload"
+	return avisess.restMultipartFileObjectUploadRequest("POST", fileLocPtr, url, nil, 0, tenant, fileParams)
 }
 
 // restMultipartFileObjectUploadRequest makes a REST request to the Avi Controller's fileobject/upload REST API using
 // POST to upload a file.
 // Return status of multipart upload.
-func (avisess *AviSession) restMultipartFileObjectUploadRequest(verb string, filePathPtr *os.File,
+func (avisess *AviSession) restMultipartFileObjectUploadRequest(verb string, filePathPtr *os.File, url string,
 	lastErr error, retryNum int, tenant string, fileParams map[string]string) error {
-	url := avisess.prefix + "/api/fileobject/upload"
 
 	if errorResult := avisess.checkRetryForSleep(retryNum, verb, url, lastErr); errorResult != nil {
 		return errorResult
@@ -152,7 +158,7 @@ func (avisess *AviSession) restMultipartFileObjectUploadRequest(verb string, fil
 			return err
 		}
 		// Doing this so that a new request is made to the
-		return avisess.restMultipartFileObjectUploadRequest("POST", filePathPtr, err, retryNum+1, tenant, fileParams)
+		return avisess.restMultipartFileObjectUploadRequest("POST", filePathPtr, url, err, retryNum+1, tenant, fileParams)
 	}
 
 	defer resp.Body.Close()


### PR DESCRIPTION
Waf team has exposed the new endpoint which expects the body of the data as multipart form data but they don't preserve the file at all. they create the object and discard the file. 
So, SDK did not have any functionality to support this and Rakshit is blocked on this requirement as he needs to use the SDK code to upload the app security data downloaded from portal.

