### PR TITLE
NetScaler GSLB fixes

### DIFF
--- a/python/avi/migrationtools/netscaler_converter/gslb_config_converter.py
+++ b/python/avi/migrationtools/netscaler_converter/gslb_config_converter.py
@@ -14,12 +14,12 @@ LOG = logging.getLogger(__name__)
 # Creating object for util library.
 ns_util = NsUtil()
 
-def get_vip_cluster_map(sites):
+def get_vip_cluster_map(sites, tenant_name):
     vip_map=dict()
     for site in sites:
         session = ApiSession.get_session(
             site['ip_addresses'][0]['addr'], site['username'], site['password'])
-        resp = session.get('virtualservice', api_version='17.1.1')
+        resp = session.get('virtualservice', tenant=tenant_name, api_version='17.1.1')
         vs_list = json.loads(resp.text)['results']
         for vs in vs_list:
             vip_map.update(create_map_for_vs(vs, vip_map, site))
@@ -49,7 +49,7 @@ def convert(gslb_config_dict, controller_ip, user_name,
         resp = session.get('configuration/export?full_system=true')
         avi_config = json.loads(resp.text)
         sites = avi_config['Gslb'][0]['sites']
-        vip_cluster_map = get_vip_cluster_map(sites)
+        vip_cluster_map = get_vip_cluster_map(sites, tenant_name)
     avi_gslb_config = None
     try:
         avi_gslb_config = dict()

--- a/python/avi/migrationtools/netscaler_converter/gslb_config_converter.py
+++ b/python/avi/migrationtools/netscaler_converter/gslb_config_converter.py
@@ -39,7 +39,7 @@ def create_map_for_vs(vs, vip_map, site):
     return vip_map
 
 
-def convert(meta, gslb_config_dict, controller_ip, user_name,
+def convert(gslb_config_dict, controller_ip, user_name,
             password, tenant_name, vs_state, output_dir, version,
             report_name, vs_level_status):
     vip_cluster_map = None
@@ -53,7 +53,6 @@ def convert(meta, gslb_config_dict, controller_ip, user_name,
     avi_gslb_config = None
     try:
         avi_gslb_config = dict()
-        avi_gslb_config['META'] = meta
         gslb_vs_converter = GslbVsConverter()
         avi_config = gslb_vs_converter.convert(
             gslb_config_dict, avi_gslb_config, vs_state, vip_cluster_map)

--- a/python/avi/migrationtools/netscaler_converter/gslb_vs_converter.py
+++ b/python/avi/migrationtools/netscaler_converter/gslb_vs_converter.py
@@ -65,7 +65,7 @@ class GslbVsConverter(object):
                 "tenant_ref": "/api/tenant/?name=admin",
                 "controller_health_status_enabled": True,
                 "wildcard_match": False,
-                "enabled": vs_state,
+                "enabled": vs_state == "enable",
                 "ttl": ttl,
                 "domain_names": domains,
                 "use_edns_client_subnet": True,

--- a/python/avi/migrationtools/netscaler_converter/netscaler_gslb_converter.py
+++ b/python/avi/migrationtools/netscaler_converter/netscaler_gslb_converter.py
@@ -1,6 +1,7 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache License 2.0
 
+#!/usr/bin/env python3.7
 import argparse
 import logging
 import avi.migrationtools
@@ -66,10 +67,8 @@ class NetscalerGSLBConverter(AviConverter):
         gslb_ns_config['bind gslb vserver'] = ns_config.get('bind gslb vserver')
         gslb_ns_config['add server'] = ns_config.get('add server')
         print(gslb_ns_config)
-        # getting meta tag from superclass
-        meta = self.meta(self.tenant, self.controller_version)
         avi_gslb_config = gslb_config_converter.convert(
-            meta, gslb_ns_config, self.controller_ip, self.user, self.password,
+            gslb_ns_config, self.controller_ip, self.user, self.password,
             self.tenant, self.vs_state, self.output_file_path, self.version,
             report_name, self.vs_level_status)
         self.write_output(


### PR DESCRIPTION
Couple of bug fixes related to the NetScaler GSLB conversion
- Respect the tenant when fetching the vip cluster map in the NetScaler GSLB conversion
- Fix the 'enabled' flag value when converting NetScaler GSLB
- Remove the meta obj reference from the NetScaler GSLB as it is no longer available in the superclass