### PR TITLE
Add params argument to _get_uuid_by_name

### DIFF
--- a/python/avi/sdk/avi_api.py
+++ b/python/avi/sdk/avi_api.py
@@ -930,7 +930,7 @@ class ApiSession(Session):
         returns session's response object
         """
         uuid = self._get_uuid_by_name(path, name, tenant, tenant_uuid,
-                                      api_version=api_version)
+                                      params=params, api_version=api_version)
         if not uuid:
             raise ObjectNotFound("%s/?name=%s" % (path, name))
         path = '%s/%s' % (path, uuid)
@@ -1063,10 +1063,11 @@ class ApiSession(Session):
             return self.prefix + '/api/' + path
 
     def _get_uuid_by_name(self, path, name, tenant='admin',
-                          tenant_uuid='', api_version=None):
+                          params=None, tenant_uuid='', api_version=None):
         """gets object by name and service path and returns uuid"""
         resp = self.get_object_by_name(
-            path, name, tenant, tenant_uuid, api_version=api_version)
+            path, name, tenant, tenant_uuid, params=params,
+            api_version=api_version)
         if not resp:
             raise ObjectNotFound("%s/%s" % (path, name))
         return self.get_obj_uuid(resp)

--- a/python/avi/sdk/avi_api.py
+++ b/python/avi/sdk/avi_api.py
@@ -880,8 +880,8 @@ class ApiSession(Session):
             session creation
         returns session's response object
         """
-        uuid = self._get_uuid_by_name(
-            path, name, tenant, tenant_uuid, api_version=api_version)
+        uuid = self._get_uuid_by_name(path, name, tenant, tenant_uuid,
+                                      params=params, api_version=api_version)
         path = '%s/%s' % (path, uuid)
         return self.put(path, data, tenant, tenant_uuid, timeout=timeout,
                         params=params, api_version=api_version, **kwargs)


### PR DESCRIPTION
The `delete_by_name()` and `put_by_name()` methods of `ApiSession()` accept the `params` argument; however, they do not actually use it in the `_get_uuid_by_name()` call. This can be problematic if you have two objects with the same name that exist in different clouds.

This PR adds params to those calls and associated methods.