### PR TITLE
AV-103074: F5 Migration Tools Enhancements

### DIFF
--- a/python/avi/migrationtools/avi_migration_utils.py
+++ b/python/avi/migrationtools/avi_migration_utils.py
@@ -861,7 +861,7 @@ class MigrationUtil(object):
                 sername = obj_dict[key]
                 if avi_graph.has_node(sername):
                     node_type = [n[1]['type'] for n in list(
-                        avi_graph.nodes().data()) if n[0] == sername]
+                        avi_graph.nodes(data=True)) if n[0] == sername]
                     node_type = '{}-{}'.format(node_type[0], 'Server')
                     avi_graph.add_node(sername, type=node_type)
                     avi_graph.add_edge(vsname, sername)
@@ -872,7 +872,7 @@ class MigrationUtil(object):
                 rule_name = obj_dict[key]
                 if avi_graph.has_node(rule_name):
                     node_type = [n[1]['type'] for n in list(
-                        avi_graph.nodes().data()) if n[0] == rule_name]
+                        avi_graph.nodes(data=True)) if n[0] == rule_name]
                     node_type = '{}-{}'.format(node_type[0], 'Rule')
                     avi_graph.add_node(rule_name, type=node_type)
                     avi_graph.add_edge(vsname, rule_name)
@@ -901,7 +901,7 @@ class MigrationUtil(object):
             found_obj = found_obj[0]
             if avi_graph.has_node(name):
                 nod_type = [node[1]['type'] for node in list(
-                    avi_graph.nodes().data()) if node[0] == name]
+                    avi_graph.nodes(data=True)) if node[0] == name]
                 nod_type = '{}-{}'.format(nod_type[0], path_key_map[entity])
                 avi_graph.add_node(name, type=nod_type)
                 avi_graph.add_edge(vsname, name)
@@ -1135,7 +1135,7 @@ class MigrationUtil(object):
                 nodelist = [node]
                 self.get_predecessor(nodelist, avi_graph, vs, tmplist)
         elif len(predecessor):
-            node_obj = [nod for nod in list(avi_graph.nodes().data()) if
+            node_obj = [nod for nod in list(avi_graph.nodes(data=True)) if
                         nod[0] == predecessor[0]]
             if node_obj and (node_obj[0][1]['type'] == 'VS' or 'VS' in node_obj[
                 0][1]['type']):

--- a/python/avi/migrationtools/f5_converter/command_status.yaml
+++ b/python/avi/migrationtools/f5_converter/command_status.yaml
@@ -290,6 +290,12 @@ VERSION_11:
     - 'defaults-from'
     - 'peer-cert-mode'
     - "partition"
+    - "passphrase"
+    - "ocsp-stapling"
+    - "alert-timeout"
+    - "session-ticket-timeout"
+    - "sni-default"
+    - "server-name"
 
     Profile_na_http:
     - 'lws-width'
@@ -312,6 +318,9 @@ VERSION_11:
     - "header-insert"
     - "partition"
     - "redirect-rewrite"
+    - "via-host-name"
+    - "via-request"
+    - "hsts"
 
     Profile_supported_http_enforcement:
     - "max-header-size"
@@ -418,6 +427,7 @@ VERSION_11:
     - 'pva-flow-aging'
     - 'pva-flow-evict'
     - 'pva-offload-state'
+    - 'link-qos-to-client'
 
     Profile_indirect_l4:
     - 'reset-on-timeout'
@@ -437,13 +447,14 @@ VERSION_11:
     - 'syn-cookie-whitelist'
     - 'rtt-from-client'
     - 'rtt-from-server'
-    - 'link-qos-to-client'
     - 'tcp-generate-isn'
     - 'ip-tos-to-client'
     - 'server-sack'
     - 'receive-window-size'
     - 'reassemble-fragments'
     - 'syn-cookie-enable'
+    - 'keep-alive-interval'
+    - 'init-rwnd'
 
     Profile_supported_fh:
     - "description"
@@ -510,6 +521,8 @@ VERSION_11:
     - 'early-retransmit'
     - 'ack-on-push'
     - 'close-wait-timeout'
+    - 'init-rwnd'
+    - 'keep-alive-interval'
 
     Profile_na_tcp:
     - 'hardware-syn-cookie'
@@ -529,6 +542,7 @@ VERSION_11:
     - "syn-rto-base"
     - "zero-window-timeout"
     - 'fin-wait-2-timeout'
+    - 'link-qos-to-client'
 
     Profile_supported_udp:
     - "description"
@@ -538,11 +552,15 @@ VERSION_11:
     - "partition"
 
     Profile_indirect_udp:
-    - 'link-qos-to-client'
     - 'proxy-mss'
     - 'ip-tos-to-client'
     - 'allow-no-payload'
     - 'datagram-load-balancing'
+    - 'keep-alive-interval'
+    - 'init-rwnd'
+
+    Profile_na_udp:
+    - 'link-qos-to-client'
 
     Profile_supported_oc:
     - 'defaults-from'
@@ -562,6 +580,8 @@ VERSION_11:
     - 'rate-limit'
     - 'connection-limit'
     - "partition"
+    - "mirror"
+    - "nat64"
 
     VS_na_attr:
     - 'vs-index'
@@ -960,13 +980,14 @@ VERSION_10:
     - 'syn cookie whitelist'
     - 'rtt from client'
     - 'rtt from server'
-    - 'link qos to client'
     - 'tcp generate isn'
     - 'ip tos to client'
     - 'server sack'
     - 'receive window size'
     - 'reassemble fragments'
     - 'syn-cookie-enable'
+    - 'init-rwnd'
+    - 'keep-alive-interval'
 
     profile_na_l4:
     - "hardware-syn-cookie"
@@ -977,6 +998,7 @@ VERSION_10:
     - 'pva-flow-aging'
     - 'pva-flow-evict'
     - 'pva-offload-state'
+    - 'link qos to client'
 
     Profile_supported_fh:
     - "description"
@@ -1037,6 +1059,8 @@ VERSION_10:
     - 'early retransmit'
     - 'ack-on-push'
     - 'close-wait-timeout'
+    - 'init-rwnd'
+    - 'keep-alive-interval'
 
     Profile_na_tcp:
     - 'hardware-syn-cookie'
@@ -1056,19 +1080,24 @@ VERSION_10:
     - "syn-rto-base"
     - "zero-window-timeout"
     - 'fin-wait-2-timeout'
+    - 'link qos to client'
 
 
     Profile_indirect_udp:
-    - 'link qos to client'
     - 'proxy mss'
     - 'ip tos to client'
     - 'allow no payload'
     - 'datagram load balancing'
+    - 'init-rwnd'
+    - 'keep-alive-interval'
 
     Profile_supported_udp:
     - "idle timeout"
     - "datagram lb"
     - "defaults from"
+
+    Profile_na_udp:
+    - 'link qos to client'
 
     Profile_supported_oc:
     - 'defaults from'
@@ -1088,6 +1117,7 @@ VERSION_10:
     - 'translate service'
     - 'source'
     - 'limit'
+    - "mirror"
 
     VS_na_attr:
     - 'vs-index'

--- a/python/avi/migrationtools/f5_converter/datagroup_converter.py
+++ b/python/avi/migrationtools/f5_converter/datagroup_converter.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache License 2.0
 
 import logging
+import yaml
 import avi.migrationtools.f5_converter.converter_constants as final
 from avi.migrationtools.f5_converter.conversion_util import F5Util
 from avi.migrationtools.avi_migration_utils import update_count
@@ -36,7 +37,7 @@ class DataGroupConfigConv(object):
                                   final.STATUS_NOT_SUPPORTED, msg)
 
     def update_conversion_status(self, conv_status, dg_type, name,
-                                 data_group):
+                                 data_group,f5_dg_config):
         """
 
         :param conv_status:  state of conversion
@@ -46,7 +47,7 @@ class DataGroupConfigConv(object):
         :return:
         """
         conv_utils.add_conv_status('data-group', dg_type, name, conv_status,
-                                   [{'data-group': data_group}])
+                                   [{'data-group': data_group}],f5_object=yaml.dump(f5_dg_config))
         LOG.debug("Conversion successful for data group: %s" %
                   name)
 
@@ -134,7 +135,7 @@ class DataGroupConfigConv(object):
                 conv_status = conv_utils.get_conv_status(
                     skipped, dict(), dict(), ip_group, user_ignore)
                 self.update_conversion_status(conv_status, dg_type, name,
-                                              ip_group)
+                                              ip_group,dg_config)
             except:
                 update_count('error')
                 LOG.error("Failed to convert data-group : %s" % key,

--- a/python/avi/migrationtools/f5_converter/f5_config_converter.py
+++ b/python/avi/migrationtools/f5_converter/f5_config_converter.py
@@ -121,7 +121,7 @@ def convert(f5_config, output_dir, vs_state, input_dir, version,
                              merge_object_mapping, sys_dict)
 
         policy_conv = PolicyConfigConv.get_instance(version, f5_attributes, prefix)
-        policy_conv.convert(f5_config, avi_config_dict, tenant)
+        policy_conv.convert(f5_config, avi_config_dict, tenant, cloud_name)
 
         vs_conv = VSConfigConv.get_instance(
             version, f5_attributes, prefix, con_snatpool, custom_mappings,
@@ -136,6 +136,8 @@ def convert(f5_config, output_dir, vs_state, input_dir, version,
                         tenant, merge_object_mapping, sys_dict)
         #removing verified_accept key from network profile
         conv_utils.remove_verified_accept_from_network_profile(avi_config_dict)
+        # removing via-host info from http profiles
+        conv_utils.remove_via_host_from_app_profiles(avi_config_dict)
         # Updating application profile from L4 to http if service has ssl enable
         conv_utils.update_app_profile(avi_config_dict, sys_dict)
         # Updated network profile to TCP PROXY if application profile is HTTP

--- a/python/avi/migrationtools/f5_converter/monitor_converter.py
+++ b/python/avi/migrationtools/f5_converter/monitor_converter.py
@@ -4,6 +4,7 @@
 import copy
 import logging
 import os
+import yaml
 import avi.migrationtools.f5_converter.converter_constants as conv_const
 from pkg_resources import parse_version
 from avi.migrationtools.f5_converter.profile_converter import ssl_count
@@ -267,7 +268,7 @@ class MonitorConfigConv(object):
                 conv_utils.add_conv_status(
                     'monitor', monitor_type, m_name, {
                         'status': conv_const.STATUS_SUCCESSFUL
-                    }, [{'health_monitor': avi_monitor}])
+                    }, [{'health_monitor': avi_monitor}],yaml.dump(f5_monitor))
                 continue
             # Added prefix for objects
             if self.prefix:
@@ -451,7 +452,7 @@ class MonitorConfigConv(object):
             u_ignore, na_list)
 
         conv_utils.add_conv_status('monitor', monitor_type, name, conv_status,
-                                   [{'health_monitor': monitor_dict}])
+                                   [{'health_monitor': monitor_dict}],yaml.dump(f5_monitor))
         return monitor_dict
 
 

--- a/python/avi/migrationtools/f5_converter/persistence_converter.py
+++ b/python/avi/migrationtools/f5_converter/persistence_converter.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache License 2.0
 
 import logging
+import yaml
 import avi.migrationtools.f5_converter.converter_constants as final
 import avi.migrationtools.f5_converter.converter_constants as conv_const
 from avi.migrationtools.f5_converter.profile_converter import ProfileConfigConv
@@ -44,7 +45,7 @@ class PersistenceConfigConv(object):
         pass
 
     def update_conversion_status(self, conv_status, persist_mode, name,
-                                 persist_profile):
+                                 persist_profile,f5_profile):
         pass
 
     def update_conv_status_for_error(self, name, persist_mode, key):
@@ -154,7 +155,7 @@ class PersistenceConfigConv(object):
                     skipped, self.indirect, ignore_for_defaults,
                     profile, u_ignore)
                 self.update_conversion_status(conv_status, persist_mode,
-                                              name, persist_profile)
+                                              name, persist_profile, profile)
             except:
                 update_count('error')
                 LOG.error("Failed to convert persistance profile : %s" % key,
@@ -304,7 +305,7 @@ class PersistenceConfigConvV11(PersistenceConfigConv):
         return persist_profile
 
     def update_conversion_status(self, conv_status, persist_mode, name,
-                                 persist_profile):
+                                 persist_profile,f5_profile):
         """
 
         :param conv_status:  state of conversion
@@ -315,7 +316,7 @@ class PersistenceConfigConvV11(PersistenceConfigConv):
         """
         conv_utils.add_conv_status('persistence', persist_mode, name,
                                    conv_status,
-                                   [{'app_per_profile': persist_profile}])
+                                   [{'app_per_profile': persist_profile}],f5_object=yaml.dump(f5_profile))
         LOG.debug("Conversion successful for persistence profile: %s" %
                   name)
 
@@ -452,7 +453,7 @@ class PersistenceConfigConvV10(PersistenceConfigConv):
         return persist_profile
 
     def update_conversion_status(self, conv_status, persist_mode, name,
-                                 persist_profile):
+                                 persist_profile,f5_profile):
         """
 
         :param conv_status:  state of conversion
@@ -462,7 +463,7 @@ class PersistenceConfigConvV10(PersistenceConfigConv):
         :return:
         """
         conv_utils.add_conv_status('persistence', 'persist', name, conv_status,
-                                   [{'app_per_profile': persist_profile}])
+                                   [{'app_per_profile': persist_profile}],f5_object=yaml.dump(f5_profile))
         LOG.debug("Conversion successful for persistence profile: %s" %
                   name)
 

--- a/python/avi/migrationtools/f5_converter/pool_converter.py
+++ b/python/avi/migrationtools/f5_converter/pool_converter.py
@@ -4,6 +4,7 @@
 import logging
 import copy
 import re
+import yaml
 import avi.migrationtools.f5_converter.converter_constants as conv_const
 from avi.migrationtools.f5_converter.conversion_util import F5Util
 from avi.migrationtools.avi_migration_utils import update_count
@@ -212,7 +213,7 @@ class PoolConfigConv(object):
         return is_pool_group, pg_dict
 
     def add_status(self, name, skipped_attr, member_skipped, skipped_monitors,
-                   converted_objs, user_ignore, skipped_servers):
+                   converted_objs, user_ignore, skipped_servers,f5_pool):
         skipped = []
         conv_status = dict()
         conv_status['user_ignore'] = []
@@ -256,7 +257,7 @@ class PoolConfigConv(object):
         conv_status['status'] = status
 
         conv_utils.add_conv_status('pool', None, name, conv_status,
-                                   converted_objs)
+                                   converted_objs,yaml.dump(f5_pool))
 
     def convert_for_pg(self, pg_dict, pool_obj, name, tenant, avi_config,
                        cloud_ref):
@@ -422,7 +423,7 @@ class PoolConfigConvV11(PoolConfigConv):
             skipped_attr.append('Skipped: length of servers more than 400')
         super(PoolConfigConvV11, self).add_status(
             pool_name, skipped_attr, member_skipped_config, skipped_monitors,
-            converted_objs, user_ignore, skipped_servers)
+            converted_objs, user_ignore, skipped_servers,f5_pool)
 
         return converted_objs
 
@@ -666,7 +667,7 @@ class PoolConfigConvV10(PoolConfigConv):
             skipped_attr.append('Skipped: length of servers more than 400')
         super(PoolConfigConvV10, self).add_status(
             pool_name, skipped_attr, member_skipped_config, skipped_monitors,
-            converted_objs, user_ignore, skipped_servers)
+            converted_objs, user_ignore, skipped_servers,f5_pool)
         return converted_objs
 
     def get_avi_lb_algorithm(self, f5_algorithm):

--- a/python/avi/migrationtools/f5_converter/profile_converter.py
+++ b/python/avi/migrationtools/f5_converter/profile_converter.py
@@ -13,7 +13,8 @@ LOG = logging.getLogger(__name__)
 ssl_count = {'count': 0}
 # Creating f5 object for util library.
 conv_utils = F5Util()
-
+ssl_profile_with_sni_parent=[]
+ssl_profile_with_sni_child = dict()
 
 class ProfileConfigConv(object):
     @classmethod
@@ -120,6 +121,7 @@ class ProfileConfigConv(object):
                     input_dir, u_ignore, tenant, key_and_cert_mapping_list,
                     merge_object_mapping, sys_dict)
                 LOG.debug("Conversion successful for profile: %s" % name)
+                            
             except:
                 update_count('error')
                 LOG.error("Failed to convert profile: %s" % key, exc_info=True)
@@ -140,7 +142,16 @@ class ProfileConfigConv(object):
         LOG.debug("Converted %s profiles" % count)
         f5_config.pop("profile")
         del key_and_cert_mapping_list
-
+    
+        if len(merge_object_mapping.get('ssl_profile'))>1:
+          
+            for ssl_index,ssl_parent in enumerate(ssl_profile_with_sni_parent):
+                merged_ssl_parent = merge_object_mapping['ssl_profile'].get(ssl_parent)
+                ssl_profile_with_sni_parent[ssl_index]=merged_ssl_parent
+             
+            temp_ssl_child= dict((merge_object_mapping['ssl_profile'].get(k), v) for k, v in ssl_profile_with_sni_child.items())
+            ssl_profile_with_sni_child.update(temp_ssl_child)   
+            
     def update_with_default_profile(self, profile_type, profile,
                                     profile_config, profile_name):
         """
@@ -168,7 +179,7 @@ class ProfileConfigConv(object):
         return profile
 
     def update_key_cert_obj(self, name, key_file_name, cert_file_name,
-                            input_dir, tenant, avi_config, converted_objs,
+                            input_dir, tenant, avi_config, profile,converted_objs,
                             default_profile_name, key_and_cert_mapping_list,
                             merge_object_mapping, sys_dict):
         """
@@ -215,7 +226,7 @@ class ProfileConfigConv(object):
             # Check kay is passphrase protected or not
             is_key_protected = conv_utils.is_certificate_key_protected(
                 input_dir + os.path.sep + key_file_name)
-
+            
         if cert and key:
             # Flag to check expiry date of certificate. if expired then
             # create placeholder certificate.
@@ -248,6 +259,8 @@ class ProfileConfigConv(object):
                 'certificate': cert,
                 'type': 'SSL_CERTIFICATE_TYPE_VIRTUALSERVICE'
             }
+        if profile.get("ocsp-stapling")=="enabled":
+            ssl_kc_obj['enable_ocsp_stapling']=True
         if key_passphrase:
             ssl_kc_obj['key_passphrase'] = key_passphrase
         if ssl_kc_obj:
@@ -275,7 +288,7 @@ class ProfileConfigConv(object):
                 avi_config['SSLKeyAndCertificate'].append(ssl_kc_obj)
 
     def update_ca_cert_obj(self, name, ca_cert_file_name, input_dir, tenant,
-                           avi_config, converted_objs, merge_object_mapping,
+                           avi_config, profile,converted_objs, merge_object_mapping,
                            sys_dict):
         """
         This method create the certs if certificate not present at location
@@ -340,6 +353,8 @@ class ProfileConfigConv(object):
                 'type': 'SSL_CERTIFICATE_TYPE_CA'
             }
             LOG.info('Added new ca certificate for %s' % name)
+            if profile.get("ocsp-stapling")=="enabled":
+                ca_cert_obj['enable_ocsp_stapling']=True
         if ca_cert_obj and self.object_merge_check:
             if final.PLACE_HOLDER_STR not in ca_cert_obj['name']:
                 conv_utils.update_skip_duplicates(
@@ -421,6 +436,7 @@ class ProfileConfigConvV11(ProfileConfigConv):
         self.na_tcp = f5_profile_attributes['Profile_na_tcp']
         self.supported_udp = f5_profile_attributes['Profile_supported_udp']
         self.indirect_udp = f5_profile_attributes['Profile_indirect_udp']
+        self.na_udp = f5_profile_attributes['Profile_na_udp']
         self.supported_oc = f5_profile_attributes['Profile_supported_oc']
         self.supported_enf = \
             f5_profile_attributes['Profile_supported_http_enforcement']
@@ -531,7 +547,7 @@ class ProfileConfigConvV11(ProfileConfigConv):
                             '/', 1)[-1]
             parent_cls.update_key_cert_obj(
                 cert_name, key_file, cert_file, input_dir, tenant_ref,
-                avi_config, converted_objs, default_profile_name,
+                avi_config, profile,converted_objs, default_profile_name,
                 key_and_cert_mapping_list, merge_object_mapping, sys_dict)
             if profile.get('chain', 'none') != 'none':
                 LOG.debug("Migrating root/intermediate cert for %s" % name)
@@ -545,7 +561,7 @@ class ProfileConfigConvV11(ProfileConfigConv):
                             'cache-path'].rsplit('/', 1)[-1]
                         break
                 self.update_ca_cert_obj(
-                    name, ca_cert_file, input_dir, tenant, avi_config,
+                    name, ca_cert_file, input_dir, tenant, avi_config, profile,
                     converted_objs, merge_object_mapping,
                     sys_dict)
 
@@ -578,6 +594,11 @@ class ProfileConfigConvV11(ProfileConfigConv):
                 accepted_versions.append({"type": "SSL_VERSION_TLS1_2"})
             if accepted_versions:
                 ssl_profile["accepted_versions"] = accepted_versions
+            if profile.get('alert-timeout'):
+                ssl_profile["ssl_session_timeout"]=profile.get('alert-timeout')
+            if profile.get("session-ticket-timeout"):
+                ssl_profile["ssl_session_timeout"]=profile.get('session-ticket-timeout')
+                
             if self.object_merge_check:
                 conv_utils.update_skip_duplicates(
                     ssl_profile, avi_config['SSLProfile'], 'ssl_profile',
@@ -588,8 +609,14 @@ class ProfileConfigConvV11(ProfileConfigConv):
             else:
                 converted_objs.append({'ssl_profile': ssl_profile})
                 avi_config['SSLProfile'].append(ssl_profile)
+            if profile.get("sni-default") == 'true':
+                ssl_profile_with_sni_parent.append(ssl_profile.get("name"))
+            elif profile.get("server-name") != "none": 
+                ssl_profile_with_sni_child[ssl_profile.get("name")]=profile.get("server-name") 
             crl_file_name = profile.get('crl-file', None)
             ca_file_name = profile.get('ca-file', None)
+            if ca_file_name == None:
+                ca_file_name = profile.get("client-cert-ca",None)
             if crl_file_name and crl_file_name != 'none':
                 crl_file_name = crl_file_name.replace('\"', '').strip()
             else:
@@ -598,7 +625,7 @@ class ProfileConfigConvV11(ProfileConfigConv):
                 ca_file_name = ca_file_name.replace('\"', '').strip()
             else:
                 ca_file_name = None
-
+            
             if ca_file_name and not self.skip_pki:
                 pki_profile = dict()
                 file_path = input_dir + os.path.sep + ca_file_name
@@ -669,8 +696,14 @@ class ProfileConfigConvV11(ProfileConfigConv):
             http_profile['secure_cookie_enabled'] = encpt_cookie
             http_profile['xff_enabled'] = insert_xff
             http_profile['connection_multiplexing_enabled'] = con_mltplxng
+            if profile.get('via-host-name'):
+                app_profile['via-host-name'] = profile.get('via-host-name')
+                app_profile['via-request'] = profile.get('via-request')
             if not profile.get('redirect-rewrite'):
                 http_profile['hsts_enabled'] = True
+            if profile.get("hsts"):
+                if profile["hsts"].get("mode")=="enabled":
+                    http_profile["hsts_enabled"] = True
             enforcement = profile.get('enforcement', None)
             if enforcement:
                 header_size = enforcement.get('max-header-size',
@@ -1125,6 +1158,7 @@ class ProfileConfigConvV11(ProfileConfigConv):
         elif profile_type == 'udp':
             supported_attr = self.supported_udp
             indirect = self.indirect_udp
+            na_list = self.na_udp
             u_ignore = user_ignore.get('udp', [])
             skipped = [attr for attr in profile.keys()
                        if attr not in supported_attr]
@@ -1161,7 +1195,7 @@ class ProfileConfigConvV11(ProfileConfigConv):
             conv_status['default_skip'].append(
                 {"enforcement": enf_skip_defaults})
         conv_utils.add_conv_status('profile', profile_type, name, conv_status,
-                                   converted_objs)
+                                   converted_objs,yaml.dump(profile) )
 
 
 class ProfileConfigConvV10(ProfileConfigConv):
@@ -1198,6 +1232,7 @@ class ProfileConfigConvV10(ProfileConfigConv):
         self.supported_udp = f5_profile_attributes['Profile_supported_udp']
         self.na_tcp = f5_profile_attributes['Profile_na_tcp']
         self.indirect_udp = []
+        self.na_udp = f5_profile_attributes['Profile_na_udp']
         self.supported_oc = f5_profile_attributes['Profile_supported_oc']
         self.supported_enf = []
         self.ignore_for_defaults_enf = []
@@ -1293,6 +1328,11 @@ class ProfileConfigConvV10(ProfileConfigConv):
             ssl_profile['name'] = name
             ssl_profile['tenant_ref'] = conv_utils.get_object_ref(
                 tenant, 'tenant')
+            if profile.get('alert-timeout'):
+                ssl_profile["ssl_session_timeout"]=profile.get('alert-timeout')
+            if profile.get("ssl-ticket-timeout"):
+                ssl_profile["ssl_session_timeout"]=profile.get('ssl-ticket-timeout')
+                
             ssl_profile['accepted_ciphers'] = self.ciphers
             close_notify = profile.get('unclean shutdown', None)
             if close_notify and close_notify == 'enabled':
@@ -1631,6 +1671,7 @@ class ProfileConfigConvV10(ProfileConfigConv):
         elif profile_type == 'udp':
             u_ignore = user_ignore.get('udp', [])
             supported_attr = self.supported_udp
+            na_list = self.na_udp
             skipped = [attr for attr in profile.keys()
                        if attr not in supported_attr]
             per_pkt = profile.get("datagram lb", 'disable')
@@ -1668,7 +1709,7 @@ class ProfileConfigConvV10(ProfileConfigConv):
         conv_status = conv_utils.get_conv_status(
             skipped, indirect, default_ignore, profile, u_ignore, na_list)
         conv_utils.add_conv_status('profile', profile_type, name, conv_status,
-                                   converted_objs)
+                                   converted_objs,yaml.dump(profile))
 
     def convert_http_profile(self, profile, name, avi_config, converted_objs,
                              tenant):

--- a/python/avi/migrationtools/f5_converter/vs_converter.py
+++ b/python/avi/migrationtools/f5_converter/vs_converter.py
@@ -5,10 +5,12 @@ import logging
 import copy
 import random
 import re
+import yaml
 import avi.migrationtools.f5_converter.converter_constants as final
 from avi.migrationtools.f5_converter.conversion_util import F5Util
-from avi.migrationtools.f5_converter.policy_converter import used_pools
+from avi.migrationtools.f5_converter.policy_converter import used_pools , http_to_https_policy_rule
 from avi.migrationtools.avi_migration_utils import update_count
+from avi.migrationtools.f5_converter.profile_converter import ssl_profile_with_sni_parent, ssl_profile_with_sni_child
 from pkg_resources import parse_version
 
 LOG = logging.getLogger(__name__)
@@ -16,6 +18,8 @@ LOG = logging.getLogger(__name__)
 conv_utils = F5Util()
 used_policy = list()
 used_app_profiles = list()
+via_header_rule_dict=dict()
+policy_with_via_header=dict()
 
 class VSConfigConv(object):
     @classmethod
@@ -81,7 +85,8 @@ class VSConfigConv(object):
         :param vrf: vrf user input to put vrf ref in VS object
         :param segroup: segroup user input to put se-group ref in VS object
         :return:
-        """
+        """  
+        
         f5_snat_pools = f5_config.get("snatpool", {})
         vs_config = f5_config.get("virtual", {})
         avi_config['VirtualService'] = []
@@ -109,7 +114,7 @@ class VSConfigConv(object):
                 mapping = self.create_partition_mapping(f5_vs, vs_name)
                 partition_mapping.update(mapping)
 
-                vs_obj = self.convert_vs(
+                vs_obj , vs_sni_parent_obj= self.convert_vs(
                     vs_name, f5_vs, vs_state, avi_config, f5_snat_pools,
                     user_ignore, tenant, cloud_name, controller_version,
                     merge_object_mapping, sys_dict, f5_config, vrf, 
@@ -117,11 +122,20 @@ class VSConfigConv(object):
                 if vs_obj:
                     if segroup:
                         segroup_ref = conv_utils.get_object_ref(
-                            segroup, 'serviceenginegroup', tenant=tenant,
+                            segroup, 'serviceenginegroup', tenant="admin",
                             cloud_name=cloud_name)
                         vs_obj['se_group_ref'] = segroup_ref
                     avi_config['VirtualService'].append(vs_obj)
                     LOG.debug("Conversion successful for VS: %s" % vs_name)
+                    if vs_sni_parent_obj:
+                        if segroup:
+                            segroup_ref = conv_utils.get_object_ref(
+                            segroup, 'serviceenginegroup', tenant="admin",
+                            cloud_name=cloud_name)
+                            vs_sni_parent_obj['se_group_ref'] = segroup_ref
+                        avi_config['VirtualService'].append(vs_sni_parent_obj)
+                   # LOG.debug("Conversion successful for VS: %s" % vs_name)
+                        
             except:
                 update_count('error')
                 LOG.error("Failed to convert VS: %s" % vs_name, exc_info=True)
@@ -138,7 +152,7 @@ class VSConfigConv(object):
                    merge_object_mapping, sys_dict, f5_config, vrf=None,
                    reuse_http_policy=False):
         """
-
+    
         :param vs_name: name of virtual service.
         :param f5_vs: parsed dict of f5 virtual service.
         :param vs_state: State of created Avi VS object
@@ -182,8 +196,20 @@ class VSConfigConv(object):
             if prof_name in avi_config.get('OneConnect', []):
                 oc_prof = True
         enable_ssl = False
+        vs_sni_type = "VS_TYPE_NORMAL"
+        vh_type = "VS_TYPE_VH_SNI"
+        child_domain_name = None
+        
         if ssl_vs:
             enable_ssl = True
+            ssl_profile_name = ssl_vs[0]["profile"].split("name=")[-1]
+            if ssl_profile_name in ssl_profile_with_sni_parent:
+                vs_sni_type = "VS_TYPE_VH_PARENT"
+                
+            child_domain_name =  ssl_profile_with_sni_child.get(ssl_profile_name)
+            if child_domain_name:
+                vs_sni_type = "VS_TYPE_VH_CHILD"
+            
         app_prof_conf = conv_utils.get_vs_app_profiles(
             profiles, avi_config, tenant, self.prefix, oc_prof, enable_ssl,
             merge_object_mapping, sys_dict)
@@ -249,6 +275,7 @@ class VSConfigConv(object):
                     app_name, 'applicationprofile',
                     tenant=conv_utils.get_name(app_prof_cmd['tenant_ref']))
         destination = f5_vs.get("destination", None)
+        description =f5_vs.get("description",None)
         d_tenant, destination = conv_utils.get_tenant_ref(destination)
         # if destination is not present then skip vs.
         services_obj, ip_addr, vsvip_ref, vrf_ref = conv_utils.get_service_obj(
@@ -364,13 +391,17 @@ class VSConfigConv(object):
                 conv_utils.update_pool_for_fallback(
                     f_host, avi_config['Pool'], pool_ref)
         ip_addr = ip_addr.strip()
+        ip_type="V4"
+        if f5_vs.get("nat64",None):
+            ip_type="v6"
         matches = re.findall('^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$', ip_addr)
-        if not matches or ip_addr == '0.0.0.0':
-            LOG.warning('Avi does not support IPv6 : %s. '
-                        'Generated random ipv4 for vs: %s' % (ip_addr, vs_name))
-            vs_name += '-needs-ipv6-ip'
-            ip_addr = ".".join(map(str, (
-                random.randint(0, 255) for _ in range(4))))
+       # if not matches or ip_addr == '0.0.0.0':
+          #  LOG.warning('Avi does not support IPv6 : %s. '
+          #              'Generated random ipv4 for vs: %s' % (ip_addr, vs_name))
+          #  vs_name += '-needs-ipv6-ip'
+          #  ip_addr = ".".join(map(str, (
+          #      random.randint(0, 255) for _ in range(4))))
+        #  ip_type="V6"
 
         if app_prof_obj:
             if self.distinct_app_profile and app_prof[0] in used_app_profiles:
@@ -389,7 +420,7 @@ class VSConfigConv(object):
         vs_obj = {
             'name': vs_name,
             'description': description,
-            'type': 'VS_TYPE_NORMAL',
+            'type': vs_sni_type,
             'enabled': enabled,
             'traffic_enabled': enabled,
             'cloud_ref': conv_utils.get_object_ref(
@@ -397,9 +428,10 @@ class VSConfigConv(object):
             'services': services_obj,
             'application_profile_ref': app_prof[0],
             'vs_datascripts': [],
-            'tenant_ref': conv_utils.get_object_ref(tenant, 'tenant')
+            'tenant_ref': conv_utils.get_object_ref(tenant, 'tenant'),
+            'vh_type': vh_type
         }
-
+        
         if vrf:
             vrf_ref = conv_utils.get_object_ref(vrf, 'vrfcontext',
                                                 tenant=tenant_name,
@@ -419,17 +451,45 @@ class VSConfigConv(object):
                 conv_utils.remove_pool_group_vrf(pool_ref, avi_config)
             elif pool_ref:
                 conv_utils.remove_pool_vrf(pool_ref, avi_config)
-
+        vs_sni_parent_obj = None
+        if vs_sni_type == "VS_TYPE_VH_CHILD":
+            vs_sni_parent_obj = {
+            'name': "%s-sni-parent" % vs_name,
+            'description': description,
+            'type': "VS_TYPE_VH_PARENT",
+            'enabled': enabled,
+            'services': services_obj,
+            'traffic_enabled': enabled,
+            'cloud_ref': conv_utils.get_object_ref(
+                cloud_name, 'cloud', tenant=tenant),
+            'tenant_ref': conv_utils.get_object_ref(tenant, 'tenant'),
+            'vh_type': vh_type
+            }    
+            
         vsvip_addr = {
                 'addr': ip_addr,
-                'type': 'V4'
+                'type':ip_type
             }
         if parse_version(controller_version) >= parse_version('17.1'):
             # vs_obj['vip'] = [vip]
-            vs_obj['vsvip_ref'] = vsvip_ref
+            if vs_sni_type == "VS_TYPE_VH_CHILD":
+                vs_sni_parent_obj['vsvip_ref'] = vsvip_ref
+            else:
+                vs_obj['vsvip_ref'] = vsvip_ref
             # vs_obj['ip_address'] = vsvip_addr
         else:
-            vs_obj['ip_address'] = vsvip_addr
+            if vs_sni_type == "VS_TYPE_VH_CHILD":
+                vs_sni_parent_obj['ip_address'] = vsvip_addr
+            else:
+                vs_obj['ip_address'] = vsvip_addr
+        
+        if vs_sni_type == "VS_TYPE_VH_CHILD": 
+            vs_obj['vh_parent_vs_ref'] = conv_utils.get_object_ref( vs_sni_parent_obj.get("name"),"virtualservice",tenant=tenant,
+                                                                   cloud_name=cloud_name)
+            vs_obj["vh_domain_name"] = [child_domain_name]
+            vs_obj.pop("services")
+          #  avi_config['VirtualService'].append(vs_sni_parent_obj)
+        
         # Policy tracking starts from here
         vs_policies = [app_pol_name] if app_pol_name else []
         vs_ds_rules = None
@@ -513,7 +573,7 @@ class VSConfigConv(object):
         self.convert_translate_port(avi_config, f5_vs, app_prof[0], pool_ref,
                                     sys_dict)
         conn_limit = int(f5_vs.get(self.connection_limit, '0'))
-        if conn_limit > 0:
+        if conn_limit > 0 and vs_sni_type!="VS_TYPE_VH_CHILD":
             vs_obj["performance_limits"] = {
                 "max_concurrent_connections": conn_limit
             }
@@ -553,7 +613,7 @@ class VSConfigConv(object):
 
         if nw_policy:
             vs_obj['network_security_policy_ref'] = conv_utils.get_object_ref(
-                nw_policy, 'networksecuritypolicy', tenant=tenant)
+                nw_policy, 'networksecuritypolicy', tenant=tenant,cloud_name=cloud_name)
 
         # Checking snat conversion flag and snat info for creating
         # snat ip object
@@ -592,6 +652,8 @@ class VSConfigConv(object):
             ntwk_verified_accept = ntwk_prof_config[0].get('verified-accept')
             if ntwk_verified_accept and ntwk_verified_accept != 'disabled':
                 vs_obj['"remove_listening_port_on_vs_down'] = True
+            if ntwk_prof_config[0]['profile'].get("tcp_fast_path_profile") and  f5_vs.get("mirror")=="enabled":
+                ntwk_prof_config[0]['connection_mirror']=True
 
         if enable_ssl:
             vs_obj['ssl_profile_ref'] = ssl_vs[0]["profile"]
@@ -626,6 +688,9 @@ class VSConfigConv(object):
                                               final.STATUS_SKIPPED,
                                               msg)
                     return
+        if app_prof:
+            self.app_profile_with_via_host_name(app_name,vs_obj,avi_config,tenant,cloud_name,sys_dict,profiles,merge_object_mapping)
+            self.enabling_http_to_https_redirects_in_app_profile(app_name,vs_obj,avi_config,sys_dict)
         for attr in self.ignore_for_value:
             ignore_val = self.ignore_for_value[attr]
             actual_val = f5_vs.get(attr, None)
@@ -660,9 +725,9 @@ class VSConfigConv(object):
         conv_status['status'] = status
         review_flag = 'Yes' if needs_review else None
         conv_utils.add_conv_status('virtual', None, vs_name,
-                                   conv_status, vs_obj, review_flag)
+                                   conv_status, vs_obj, yaml.dump(f5_vs), review_flag)
 
-        return vs_obj
+        return vs_obj,vs_sni_parent_obj
 
     def get_policy_vs(self, vs_policies, avi_config, vs_name, tenant,
                       cloud_name, vs_obj, reuse_http_policy=False):
@@ -694,6 +759,8 @@ class VSConfigConv(object):
                         avi_config['HTTPPolicySet'].append(clone_policy)
                         LOG.debug('Policy cloned %s for vs %s', pol_name,
                                   vs_name)
+                        if policy_obj[0]["name"] in http_to_https_policy_rule:
+                            http_to_https_policy_rule.append(pol_name)
                     else:
                         LOG.debug('Policy with different tenant not '
                                    'supported  %s for vs %s', pol_name,
@@ -717,7 +784,108 @@ class VSConfigConv(object):
                     pol['index'] = ind + 1
                 vs_obj['http_policies'].append(pol)
 
+    def create_rule_action_for_via_header(self,via_header,via_request):
+        rule_dict={
+        "enable": True,
+         "hdr_action":
+             [{"action": "HTTP_ADD_HDR",
+               "hdr":
+                   {"name": "via",
+                    "value":
+                        {
+                            "val": via_header
+                            }
+                        }
+                   }
+              ],
+             "index" : "1",
+             "name": "Rule 1"}
+        if via_request=="append":
+            rule_dict["hdr_action"][0]["action"]="HTTP_ADD_HDR"
+        if via_request == "remove":
+            rule_dict["hdr_action"][0]["action"]="HTTP_REMOVE_HDR"
+        via_header_key="%s-%s" % (via_header,via_request)
+        via_header_rule_dict[via_header_key]=rule_dict
+        return rule_dict
 
+    def add_via_header_rule_to_http_policy(self,rule_dict,vs_obj,http_policy,tenant,avi_config,cloud_name):
+        http_policy_name = None
+        if http_policy :
+            if http_policy['http_request_policy']:
+                index=len(http_policy['http_request_policy']['rules'])+1
+                if rule_dict not in http_policy['http_request_policy']['rules']:
+                    rule_dict['index']=index
+                    http_policy['http_request_policy']["rules"].append(rule_dict)
+            else:
+                http_policy['http_request_policy']["rules"]=[rule_dict]
+            http_policy_name=http_policy['name']
+        else:
+            policy_set={
+                "name" :  "%s-HTTP-Policy-Set" % vs_obj['name'],
+                'tenant_ref' : conv_utils.get_object_ref(tenant,'tenant'),
+                'http_request_policy':{
+                    'rules':[rule_dict]
+                }
+            }
+            http_policy_name = policy_set['name']
+            avi_config['HTTPPolicySet'].append(policy_set)
+            vs_policies=[policy_set.get('name')]
+            self.get_policy_vs(vs_policies, avi_config, vs_obj['name'], tenant,
+                      cloud_name, vs_obj)
+        return http_policy_name
+
+    def app_profile_with_via_host_name(self,app_name,vs_obj,avi_config,tenant,cloud_name,sys_dict,profiles,merge_object_mapping):
+
+        application_profile_obj = \
+                [obj for obj in (sys_dict['ApplicationProfile'] +
+                                 avi_config['ApplicationProfile'])
+                 if obj['name'] == app_name]
+        f5_prof_obj = application_profile_obj
+        if f5_prof_obj and f5_prof_obj[0].get("via-host-name"):
+            f5_prof_obj = f5_prof_obj[0]
+            via_host_name = f5_prof_obj.get("via-host-name")
+            via_request = f5_prof_obj.get('via-request')
+            if via_request in ['append','remove']:
+                if via_header_rule_dict.get("%s-%s" % (via_host_name,via_request)):
+                    via_rule = via_header_rule_dict.get("%s-%s" % (via_host_name,via_request))
+                else:
+                    via_rule = self.create_rule_action_for_via_header(via_host_name,via_request)
+                pol_name = vs_obj.get('http_policies')
+                via_header_request = "%s-%s" % (via_host_name,via_request)
+                policy_name= None
+                if pol_name :
+                    http_policy_ref = pol_name[0].get("http_policy_set_ref")
+                    http_policy_name = http_policy_ref.split("name=")[-1]
+                    if http_policy_name :
+                        policy_obj = [ob for ob in avi_config['HTTPPolicySet'] if ob[
+                                'name'] == http_policy_name]
+                        if policy_with_via_header.get(http_policy_name) :
+                            if not via_header_request in policy_with_via_header.get(http_policy_name):
+                                policy_name = self.add_via_header_rule_to_http_policy(via_rule,vs_obj,policy_obj[0],tenant,avi_config,cloud_name)
+                        else:
+                            policy_name = self.add_via_header_rule_to_http_policy(via_rule,vs_obj,policy_obj[0],tenant,avi_config,cloud_name)
+                else :
+                    policy_name = self.add_via_header_rule_to_http_policy(via_rule,vs_obj,pol_name,tenant,avi_config,cloud_name)
+                if policy_name:
+                    if not policy_with_via_header.get(policy_name):
+                        policy_with_via_header[policy_name] = [via_header_request]
+                    else:
+                        policy_with_via_header[policy_name].append(via_header_request)
+
+    def enabling_http_to_https_redirects_in_app_profile(self,app_name,vs_obj,avi_config,sys_dict):
+        policy = vs_obj.get('http_policies')
+        if policy :
+            http_policy_ref = policy[0].get("http_policy_set_ref")
+            http_policy_name = http_policy_ref.split("name=")[-1]
+
+            if http_policy_name and http_policy_name in http_to_https_policy_rule:
+                app_profile_obj = \
+                        [obj for obj in (sys_dict['ApplicationProfile'] +
+                                         avi_config['ApplicationProfile'])
+                        if obj['name'] == app_name]
+                if app_profile_obj:
+                    app_profile_obj[0]['http_profile']['http_to_https']=True
+                
 class VSConfigConvV11(VSConfigConv):
     def __init__(self, f5_virtualservice_attributes, prefix, con_snatpool,
                  custom_mappings, distinct_app_profile):


### PR DESCRIPTION
Following changes are added:
1. F5 Migration Tool - Skipped Settings Update - vs
2. f5_migration.py update default run options
3. f5 configuration has to be supplied on a side in the report
4. F5 Migration Tool - Skipped Settings Update - ssl
5. F5 Migration Tool - Skipped Settings Update - policy:
6. Getting Tenant as None in f5_converter.py with args -- segroup
7. F5 Migration tool: Networkx on controller is out of date which is causing --vs_level_status to fail.
8. f5_converter.py with args cloud_name, failed to update the cloud reference in http_request_policy
9. F5 migrationtool: Delete other VSs from XL if VS_filter option is used