### PR TITLE
AV-197483: Added knob to skip datapath validations

### DIFF
--- a/python/avi/migrationtools/nsxt_converter/nsxt_config_converter.py
+++ b/python/avi/migrationtools/nsxt_converter/nsxt_config_converter.py
@@ -48,7 +48,7 @@ def convert(nsx_lb_config, input_path, output_path, tenant, prefix,
             migrate_to, object_merge_check, controller_version, ssh_root_password, nsxt_util, migration_input_config=None,
             vs_state=False, vs_level_status=False, vrf=None,
             segroup=None, not_in_use=True, custom_mapping=None, traffic_state=False, cloud_tenant="admin",
-            nsxt_ip=None, nsxt_password=None):
+            nsxt_ip=None, nsxt_password=None, skip_datapath_check=False):
 
     # load the yaml file attribute in nsxt_attributes.
     nsxt_attributes = conv_const.init()
@@ -71,7 +71,8 @@ def convert(nsx_lb_config, input_path, output_path, tenant, prefix,
         monitor_converter = MonitorConfigConv(nsxt_attributes, object_merge_check, merge_object_mapping, sys_dict)
         monitor_converter.convert(avi_config_dict, nsx_lb_config, prefix,tenant,custom_mapping)
 
-        pool_converter = PoolConfigConv(nsxt_attributes, object_merge_check, merge_object_mapping, sys_dict)
+        pool_converter = PoolConfigConv(nsxt_attributes, object_merge_check, merge_object_mapping, sys_dict,
+                                        skip_datapath_check)
         pool_converter.convert(avi_config_dict, nsx_lb_config,nsxt_util, prefix, tenant)
 
         profile_converter = ProfileConfigConv(nsxt_attributes, object_merge_check, merge_object_mapping, sys_dict)
@@ -84,7 +85,7 @@ def convert(nsx_lb_config, input_path, output_path, tenant, prefix,
         persist_conv.convert(avi_config_dict, nsx_lb_config, prefix,tenant)
 
         vs_converter = VsConfigConv(nsxt_attributes,object_merge_check, merge_object_mapping,sys_dict,
-                                    nsxt_ip, nsxt_password)
+                                    nsxt_ip, nsxt_password, skip_datapath_check=skip_datapath_check)
         vs_converter.convert(avi_config_dict, nsx_lb_config, prefix,
                              tenant, vs_state, controller_version, traffic_state,
                              cloud_tenant, ssh_root_password, nsxt_util, migration_input_config,
@@ -104,7 +105,7 @@ def convert(nsx_lb_config, input_path, output_path, tenant, prefix,
 
     # Add nsxt converter status report in xslx report
     try:
-         conv_utils.add_complete_conv_status(
+        conv_utils.add_complete_conv_status(
              output_path, avi_config_dict, "nsxt-report", vs_level_status)
     except Exception as e:
         msg = "Error in writing excel sheet for converted configuration."

--- a/python/avi/migrationtools/nsxt_converter/nsxt_converter.py
+++ b/python/avi/migrationtools/nsxt_converter/nsxt_converter.py
@@ -75,6 +75,7 @@ class NsxtConverter(AviConverter):
         self.default_params_file = args.default_params_file
         self.cloud_tenant = args.cloud_tenant
         self.ssh_root_password = args.ssh_root_password
+        self.skip_datapath_check = args.skip_datapath_check
 
     def convert_lb_config(self, args):
 
@@ -145,7 +146,7 @@ class NsxtConverter(AviConverter):
                 self.vs_state,
                 self.vs_level_status, None, self.segroup, self.not_in_use, None,
                 self.traffic_state, self.cloud_tenant,
-                self.nsxt_ip, self.nsxt_password)
+                self.nsxt_ip, self.nsxt_password, self.skip_datapath_check)
 
             avi_config = self.process_for_utils(alb_config, skip_ref_objects=["cloud_ref", "tenant_ref"])
             # Check if flag true then skip not in use object
@@ -446,6 +447,8 @@ if __name__ == "__main__":
     parser.add_argument('--vs_level_status', action='store_true',
                         help='Add columns of vs reference and overall skipped '
                              'settings in status excel sheet')
+    parser.add_argument('--skip_datapath_check', action='store_true',
+                        help='If provided will skip all the validations done for ensuring datapaths success')
     parser.add_argument('-s', '--vs_state', choices=ARG_CHOICES['vs_state'],
                         help='State of created VS. The default is \'deactivate\'.' +
                         '\n\'enable\' value means VS will be migrated with enable state. '

--- a/python/avi/migrationtools/nsxt_converter/nsxt_util.py
+++ b/python/avi/migrationtools/nsxt_converter/nsxt_util.py
@@ -784,7 +784,11 @@ class NSXUtil():
         incomplete_networks = []
 
         cloud_id = [cl.get("uuid") for cl in self.cloud if cl.get("name") == cloud_name]
-        network_list = self.session.get("network/?&cloud_ref.uuid=" + cloud_id[0]).json()["results"]
+        network_list = self.session.get("network/?&cloud_ref.uuid=" + cloud_id[0])
+        if type(network_list) == dict:
+            network_list = network_list["results"]
+        else:
+            network_list = network_list.json()["results"]
         for network in network_list:
             if 'attrs' in network:
                 for attr in network.get("attrs"):
@@ -1314,4 +1318,3 @@ class NSXUtil():
         ip_group['tenant_ref'] = conv_utils.get_object_ref(tenant, 'tenant')
         alb_config['IpAddrGroup'].append(ip_group)
         return ip_group['name']
-

--- a/python/avi/migrationtools/setup.py
+++ b/python/avi/migrationtools/setup.py
@@ -39,7 +39,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=['pyyaml', 'requests', 'pyparsing', 'paramiko', 'avisdk',
-                      'pycrypto', 'ecdsa', 'pyOpenssl', 'nose-html-reporting',
+                      'pycryptodome', 'ecdsa', 'pyOpenssl', 'nose-html-reporting',
                       'nose-testconfig', 'ConfigParser', 'xlsxwriter', 'jinja2',
                       'pandas', 'openpyxl', 'appdirs',  'pexpect',
                       'unittest2', 'networkx', 'xmltodict'],


### PR DESCRIPTION
- Added script parameter to override the behaviour for validating data path. Default is true and if parameter is provided then false (skip validation).
- Tested this with setup with pool members not falling in network ip ranges. With this flag set the pools will be anyway migrated.