### PR TITLE
AV-194538: Fixed alb config for application profile http cltTimeout property

### DIFF
--- a/python/avi/migrationtools/netscaler_converter/ns_util.py
+++ b/python/avi/migrationtools/netscaler_converter/ns_util.py
@@ -488,48 +488,36 @@ class NsUtil(MigrationUtil):
             'ApplicationProfile']) if p['name'] == profile_name]
         if profile:
             if prop_dict.get('clttimeout'):
-                profile[0]['client_header_timeout'] = int(prop_dict[
-                                                              'clttimeout'])
-                profile[0]['client_body_timeout'] = int(prop_dict['clttimeout'])
-            if prop_dict.get('xff_enabled'):
+                timeout_dict = {
+                    'client_header_timeout': int(prop_dict['clttimeout']),
+                    'client_body_timeout': int(prop_dict['clttimeout'])
+                }
                 if profile[0].get('http_profile'):
-                    profile[0]['http_profile'].update(
-                        {
-                            'xff_enabled': True,
-                            'xff_alternate_name': 'X-Forwarded-For'
-                        }
-                    )
+                    profile[0]['http_profile'].update(timeout_dict)
                 else:
-                    profile[0].update({'http_profile':
-                        {
-                            'xff_enabled': True,
-                            'xff_alternate_name': 'X-Forwarded-For'
-                        }
-                    })
+                    profile[0].update({'http_profile': timeout_dict})
+            if prop_dict.get('xff_enabled'):
+                xff_dict = {
+                    'xff_enabled': True,
+                    'xff_alternate_name': 'X-Forwarded-For'
+                }
+                if profile[0].get('http_profile'):
+                    profile[0]['http_profile'].update(xff_dict)
+                else:
+                    profile[0].update({'http_profile': xff_dict})
+            http_profile_attr_dict = {
+                'x_forwarded_proto_enabled': True,
+                'hsts_enabled': True,
+                'http_to_https': True,
+                'httponly_enabled': True,
+                'hsts_max_age': 365,
+                'server_side_redirect_to_https': True,
+                'secure_cookie_enabled': True
+            }
             if profile[0].get('http_profile'):
-                profile[0]['http_profile'].update(
-                    {
-                        'x_forwarded_proto_enabled': True,
-                        'hsts_enabled': True,
-                        'http_to_https': True,
-                        'httponly_enabled': True,
-                        'hsts_max_age': 365,
-                        'server_side_redirect_to_https': True,
-                        'secure_cookie_enabled': True
-                    }
-                )
+                profile[0]['http_profile'].update(http_profile_attr_dict)
             else:
-                profile[0].update({'http_profile':
-                    {
-                        'x_forwarded_proto_enabled': True,
-                        'hsts_enabled': True,
-                        'http_to_https': True,
-                        'httponly_enabled': True,
-                        'hsts_max_age': 365,
-                        'server_side_redirect_to_https': True,
-                        'secure_cookie_enabled': True
-                    }
-                })
+                profile[0].update({'http_profile': http_profile_attr_dict})
 
     def object_exist(self, object_type, name, avi_config):
         '''

--- a/python/avi/migrationtools/netscaler_converter/test/test_complete_vs_configuration.py
+++ b/python/avi/migrationtools/netscaler_converter/test/test_complete_vs_configuration.py
@@ -31,7 +31,7 @@ class VSConfig(unittest.TestCase):
     def test_run_input_config_over_ns_tool(self):
         os.system('python netscaler_converter/netscaler_converter.py -f '
                   'netscaler_converter/test/input_vs_configuration.conf -l '
-                  'netscaler_converter/test/certs --no_profile_merge')
+                  'netscaler_converter/test/certs')
 
     def test_pool_groups(self):
         """


### PR DESCRIPTION
Fixed alb config for application profile http cltTimeout property.

client_header_timeout and client_body_timeout are getting added as attributes of application profile object, but actually they are the application profile -> http_profile attributes. Hence ansible raises error that those are not supported attributes for app profile.

Fixed this by adding these attributes to app prof -> http profile. 
Verified this by generating ansible playbook and executing it, working fine as expected post fix.