### PR TITLE
AV-198224: Fixed NSX-T migration issues

### DIFF
--- a/python/avi/migrationtools/ansible/ansible_config_converter.py
+++ b/python/avi/migrationtools/ansible/ansible_config_converter.py
@@ -123,6 +123,10 @@ class AviAnsibleConverterBase(object):
         # query.pop('cloud', None)
         u = u._replace(query=urlencode(query, True))
         x = urlunparse(u)
+        if '+' in x:
+            # Spaces get replaced with '+' which further causes error like 'Object not found'.
+            # Hence, replacing all the '+' back to spaces
+            x = x.replace('+', ' ')
         return unquote(x)
 
     def transform_obj_refs(self, obj):

--- a/python/avi/migrationtools/nsxt_converter/conversion_util.py
+++ b/python/avi/migrationtools/nsxt_converter/conversion_util.py
@@ -1062,13 +1062,13 @@ class NsxtConvUtil(MigrationUtil):
         pool_obj = [pool for pool in avi_config['Pool'] if pool['name'] == ref
                     and pool['tenant_ref'] == self.get_object_ref(tenant,
                                                                   'tenant')]
-        pool_per_ref = pool_obj[0].get(
+        pool_persis_ref = pool_obj[0].get(
             'application_persistence_profile_ref') if pool_obj else None
-        pool_per_name = self.get_name(pool_per_ref) if pool_per_ref else None
-        pool_per_types = [obj['persistence_type'] for obj in (avi_config[
+        pool_persis_name = self.get_name(pool_persis_ref) if pool_persis_ref else None
+        pool_persis_types = [obj['persistence_type'] for obj in (avi_config[
             'ApplicationPersistenceProfile']) if obj['name'] ==
-                          pool_per_name] if pool_per_name else []
-        pool_per_type = pool_per_types[0] if pool_per_types else None
+                          pool_persis_name] if pool_persis_name else []
+        pool_persis_type = pool_persis_types[0] if pool_persis_types else None
         if not pool_obj:
             pool_group_obj = [pool for pool in avi_config['PoolGroup']
                               if pool['name'] == ref and
@@ -1149,6 +1149,8 @@ class NsxtConvUtil(MigrationUtil):
                 ref = self.clone_pool_group(ref, vs_name, avi_config, True,
                                             tenant, cloud_name=cloud_name)
             else:
+                if isinstance(shared_vs[0], str):
+                    shared_vs = [obj for obj in avi_config['VirtualService'] if obj['name'] == shared_vs[0]]
                 shared_appref = shared_vs[0].get('application_profile_ref')
                 shared_apptype = None
                 if shared_appref:
@@ -1168,7 +1170,7 @@ class NsxtConvUtil(MigrationUtil):
 
                 if self.is_pool_clone_criteria(
                         controller_version, app_prof_type, shared_apptype,
-                        persist_type, pool_per_type, shared_appobj,
+                        persist_type, pool_persis_type, shared_appobj,
                         app_prof_obj):
                     LOG.debug('Cloned the pool %s for VS %s', ref, vs_name)
                     ref = self.clone_pool(ref, vs_name, avi_config['Pool'],
@@ -1361,7 +1363,7 @@ class NsxtConvUtil(MigrationUtil):
         :param pool_ref: name of the pool
         """
         for pool_obj in avi_pool_list:
-            if pool_ref == pool_obj["name"]:
+            if pool_ref == pool_obj["name"] and pool_segment:
                 pool_obj["placement_networks"] = list()
                 for sub in pool_segment:
                     ip_addreses = dict(

--- a/python/avi/migrationtools/nsxt_converter/nsxt_util.py
+++ b/python/avi/migrationtools/nsxt_converter/nsxt_util.py
@@ -164,10 +164,10 @@ def get_certificate_data(certificate_ref, nsxt_ip, ssh_root_password):
         ssh.load_system_host_keys()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         ssh.connect(nsxt_ip, username='root', password=ssh_root_password,
-                     allow_agent=False, look_for_keys=False, banner_timeout=60)
+                    allow_agent=False, look_for_keys=False, banner_timeout=60)
 
         cmd = "curl --header 'Content-Type: application/json' --header 'x-nsx-username: admin' " \
-              "http://'admin':'{}'@127.0.0.1:7440/nsxapi/api/v1/trust-management/certificates".\
+              "http://127.0.0.1:7440/nsxapi/api/v1/trust-management/certificates".\
             format(ssh_root_password)
         stdin, stdout, stderr = ssh.exec_command(cmd)
 

--- a/python/avi/migrationtools/nsxt_converter/persistant_converter.py
+++ b/python/avi/migrationtools/nsxt_converter/persistant_converter.py
@@ -148,7 +148,7 @@ class PersistantProfileConfigConv(object):
                 conv_utils.print_progress_bar(progressbar_count, total_size, msg,
                                               prefix='Progress', suffix='')
 
-                LOG.info('[ApplicationPersistenceProfile] Migration completed for HM {}'.format(lb_pp['display_name']))
+                LOG.info('[ApplicationPersistenceProfile] Migration completed for {}'.format(lb_pp['display_name']))
 
             except Exception as e:
                 LOG.error(
@@ -276,6 +276,8 @@ class PersistantProfileConfigConv(object):
                          % (lb_pp.get('cookie_name'), lb_pp.get('cookie_path', '/'), lb_pp.get('cookie_domain'),
                             cookie_max_idle, cookie_max_life, lb_pp.get('cookie_httponly', False))
                 is_ds_created = True
+            else:
+                LOG.debug("No cookie_path or cookie_domain for {}".format(lb_pp.get('display_name')))
 
         elif lb_pp.get("cookie_mode") == 'REWRITE':
             script = "ip,port = avi.pool.get_server_info() cookie_name = \"%s\" " \

--- a/python/avi/migrationtools/nsxt_converter/policy_converter.py
+++ b/python/avi/migrationtools/nsxt_converter/policy_converter.py
@@ -287,7 +287,7 @@ class PolicyConfigConverter(object):
             [], indirect, ignore_for_defaults, [],
             u_ignore, [])
 
-        if http_rules or sec_rules or rsp_rules or self.policy_datascript_obj:
+        if http_rules or sec_rules or rsp_rules:
             conv_status["skipped"] = skipped_rule
             conv_status["na_list"] = []
             if not skipped_rule:
@@ -518,6 +518,7 @@ class PolicyConfigConverter(object):
             if action["type"] == "LBVariablePersistenceLearnAction" or \
                     action['type'] == 'LBVariablePersistenceOnAction':
                 # skip rule
+                LOG.debug("Rule action of type {} skipped".format(action["type"]))
                 continue
 
             if action["type"] == "LBHttpRequestUriRewriteAction":
@@ -643,7 +644,9 @@ class PolicyConfigConverter(object):
 
         pool_present = False
         if self.lb_vs_config["id"] in vs_select_pool_action_list.keys():
-            pool_segment = vs_pool_segment_list[self.lb_vs_config["id"]].get("pool_segment")
+            pool_segment = None
+            if self.lb_vs_config["id"] in vs_pool_segment_list:
+                pool_segment = vs_pool_segment_list[self.lb_vs_config["id"]].get("pool_segment")
             is_pg_created = False
             if pool_ref:
                 p_tenant, pool_ref = conv_utils.get_tenant_ref(pool_ref)

--- a/python/avi/migrationtools/nsxt_converter/pools_converter.py
+++ b/python/avi/migrationtools/nsxt_converter/pools_converter.py
@@ -123,7 +123,7 @@ class PoolConfigConv(object):
                         pool_seg_list,is_member_ip_in_range ,pool_skip= self.check_pool_member_ip_ranges \
                             (vs_list_for_sorry_pool, pool_count, lb_list, pool_members_list, pool_skip, name,
                              vs_sorry_pool_segment_list)
-                        if is_member_ip_in_range:
+                        if is_member_ip_in_range or self.skip_datapath_check:
                             is_sry_pool_present = True
                         is_pool_orphan=False
 
@@ -332,6 +332,7 @@ class PoolConfigConv(object):
             if member.get("port", ""):
                 server_obj['port'] = int(member.get("port"))
             else:
+                LOG.debug(f"No port value found for {member.get('display_name')}")
                 server_skipped.append(member.get("display_name"))
 
             if member.get("weight"):
@@ -533,14 +534,14 @@ class PoolConfigConv(object):
                     else:
                         new_pool_name = '%s-%s' % (pool_name, pool_segment[0].get("subnets").get("network_range"))
                         new_pool_name = new_pool_name.replace('/', '-')
-                        vs_pool_segment_list[vs_id] = {
+                        pool_segment_list[vs_id] = {
                             "pool_name": new_pool_name,
                             "pool_segment": pool_segment
                         }
                         lb_list[lb] = pool_segment_list.get(vs_id)
                     pool_count += 1
                 elif self.skip_datapath_check:
-                    vs_pool_segment_list[vs_id] = {
+                    pool_segment_list[vs_id] = {
                         "pool_name": pool_name,
                         "pool_segment": None
                     }

--- a/python/avi/migrationtools/nsxt_converter/profile_converter.py
+++ b/python/avi/migrationtools/nsxt_converter/profile_converter.py
@@ -249,3 +249,12 @@ class ProfileConfigConv(object):
             session_idle_timeout=lb_pr.get('idle_timeout')
         )
         return path
+
+
+def set_certificate_mode(t_obj_body, certificate_mode):
+    if 'http_profile' in t_obj_body.keys():
+        t_obj_body['http_profile']['ssl_client_certificate_mode'] = certificate_mode
+    else:
+        t_obj_body.update({"http_profile": {
+            "ssl_client_certificate_mode": certificate_mode
+        }})

--- a/python/avi/migrationtools/nsxt_converter/profile_converter.py
+++ b/python/avi/migrationtools/nsxt_converter/profile_converter.py
@@ -228,7 +228,7 @@ class ProfileConfigConv(object):
         alb_pr["preserve_client_ip"] = False
         if lb_pr.get("http_redirect_to"):
             # TODO
-            print("http_redirect_to")
+            LOG.debug("TODO: http_redirect_to")
 
     def convert_udp(self, alb_pr, lb_pr):
         alb_pr['profile'] = dict(

--- a/python/avi/migrationtools/nsxt_converter/vs_converter.py
+++ b/python/avi/migrationtools/nsxt_converter/vs_converter.py
@@ -720,9 +720,9 @@ class VsConfigConv(object):
                         self.add_sorry_pool_member_to_poolgroup(alb_config, main_pool_ref, sorry_pool_ref)
                     else:
                         if pool_present:
-                            self.attach_pool_to_sry_pool_group(alb_config, main_pool_ref,
+                            sorry_pool_ref = self.attach_pool_to_sry_pool_group(alb_config, main_pool_ref,
                                                             sorry_pool_ref, tenant, cloud_name)
-                        main_pool_ref = sorry_pool_ref
+                        main_pool_ref = f"{sorry_pool_ref}"
                         is_pg_created = True
 
                 if is_pg_created:
@@ -1270,7 +1270,6 @@ class VsConfigConv(object):
                       if obj['name'] == pg_ref]
         if pool_group:
             pool_group = pool_group[0]
-            pool_group['tier1_lr'] = tier1_lr
             for member in pool_group['members']:
                 pool_name = conv_utils.get_name(member['pool_ref'])
                 self.add_tier_to_pool(pool_name, alb_config, tier1_lr)
@@ -1322,6 +1321,8 @@ class VsConfigConv(object):
             pool_ref=conv_utils.get_object_ref(main_pool_ref, 'pool', tenant=tenant, cloud_name=cloud_name)
         )
         sry_pool_group['members'].append(pool_member)
+        sry_pool_group['name'] = f"{main_pool_ref}-{str(random.randint(0, 20))}"
+        return sry_pool_group['name']
 
     def update_poolgroup_with_ssl(self, alb_config, nsx_lb_config, lb_vs, pg_name,
                                   prefix, tenant,

--- a/python/avi/migrationtools/nsxt_converter/vs_converter.py
+++ b/python/avi/migrationtools/nsxt_converter/vs_converter.py
@@ -18,7 +18,7 @@ import random
 
 from avi.migrationtools.nsxt_converter.pools_converter import skipped_pools_list, vs_pool_segment_list, \
     vs_sorry_pool_segment_list, pool_name_dict
-from avi.migrationtools.nsxt_converter.profile_converter import application_profile_list, network_profile_list
+from avi.migrationtools.nsxt_converter.profile_converter import application_profile_list, network_profile_list, set_certificate_mode
 from avi.migrationtools.nsxt_converter.ssl_profile_converter import ssl_profile_list
 
 LOG = logging.getLogger(__name__)
@@ -430,7 +430,7 @@ class VsConfigConv(object):
                         for profile in alb_config["ApplicationProfile"]:
                             if merge_profile_name == profile["name"]:
                                 if client_ssl["client_auth"] == 'IGNORE':
-                                    profile["ssl_client_certificate_mode"] = 'SSL_CLIENT_CERTIFICATE_NONE'
+                                    set_certificate_mode(profile, 'SSL_CLIENT_CERTIFICATE_NONE')
                     if ssl_key_cert_refs:
                         alb_vs["ssl_key_and_certificate_refs"] = list(set(ssl_key_cert_refs))
                     skipped_client_ssl = [val for val in client_ssl.keys()


### PR DESCRIPTION
- AV-199855: Currently when sorry pool is present we create a pool group with sorry pool name. Ask is whenever primary and sorry pool is present then pool group should be created with primary pool name. Fixed this by adding name of primary pool name rather than sorry pool name. To keep name unique also appended random number so that even if pool are shared across VS’s, pool group with same name will not be created
- AV-198287: Fixed sorry config pool conversion error
- AV-200240: Fixed ansible converter issue for object names containing spaces
- AV-200557: Fix for application profile ssl_client_certificate_mode property
- AV-201245: Fixed command to fetch ssl certificates
- AV-201241: Fixed issue of missing newly created objects in nsx-t output excel
- Added a few logger statements