### PR TITLE
Add query escape to query params in GetURI

### DIFF
--- a/go/session/avisession.go
+++ b/go/session/avisession.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"os"
 	"reflect"
 	"regexp"
@@ -1505,11 +1506,11 @@ func (avisess *AviSession) GetUri(obj string, options ...ApiOptionsParams) (stri
 		return "", errors.New("Name not specified")
 	}
 
-	uri := "api/" + obj + "?name=" + opts.name
+	uri := "api/" + obj + "?name=" + url.QueryEscape(opts.name)
 	if opts.cloud != "" {
-		uri = uri + "&cloud=" + opts.cloud
+		uri = uri + "&cloud=" + url.QueryEscape(opts.cloud)
 	} else if opts.cloudUUID != "" {
-		uri = uri + "&cloud_ref.uuid=" + opts.cloudUUID
+		uri = uri + "&cloud_ref.uuid=" + url.QueryEscape(opts.cloudUUID)
 	}
 	if opts.skipDefault {
 		uri = uri + "&skip_default=true"


### PR DESCRIPTION
This PR wraps query params in `GetURI` with `url.QueryEscape` to ensure query is well formed e.g if I provide `VM Network` it will be converted into `VM+Network`. This seems to be expected in the Avi 30.1.1 API.

Fixes #2902