### PR TITLE
 Fix: Include session tokens in all the request headers

### DIFF
--- a/go/session/avisession.go
+++ b/go/session/avisession.go
@@ -759,7 +759,7 @@ func (avisess *AviSession) newAviRequest(verb string, url string, payload io.Rea
 	if tenant == "" {
 		tenant = avisess.tenant
 	}
-	if !strings.HasSuffix(url, "login") && avisess.csrfToken != "" {
+	if url != avisess.prefix+"login" && avisess.csrfToken != "" {
 		req.Header["X-CSRFToken"] = []string{avisess.csrfToken}
 		req.AddCookie(&http.Cookie{Name: "csrftoken", Value: avisess.csrfToken})
 	}
@@ -768,7 +768,7 @@ func (avisess *AviSession) newAviRequest(verb string, url string, payload io.Rea
 		req.Header.Set("X-Avi-Tenant", tenant)
 	}
 
-	if !strings.HasSuffix(url, "login") && avisess.sessionid != "" {
+	if url != avisess.prefix+"login" && avisess.sessionid != "" {
 		req.AddCookie(&http.Cookie{Name: "sessionid", Value: avisess.sessionid})
 		req.AddCookie(&http.Cookie{Name: "avi-sessionid", Value: avisess.sessionid})
 	}


### PR DESCRIPTION
Added fix to update the request headers for all the requests

Identified a crucial flaw in the current logic. The strings.HasSuffix(url, "login") check is
indeed too broad. If we have other API endpoints like `/api/user/login-history` or `/api/admin/force-login` that happen to end with "login", the current condition
!strings.HasSuffix(url, "login") will evaluate to false for these, preventing the CSRF token from
being added. This is problematic if those endpoints require a CSRF token for security.

The intent is to only exclude the primary authentication endpoint (which is avisess.prefix + "login") from receiving a CSRF token.

To fix this, I have changed the condition in newAviRequest to specifically check if the url is exactly the login URL, rather than just checking if it ends with "login".

Explanation of the change:

   * `url != avisess.prefix+"login"`: This new part of the condition precisely checks if the current
     request's full URL is not the exact login endpoint.
   * This ensures that:
       * The actual login endpoint (e.g., https://controller.com/login) will correctly not have a
         CSRF token added.
       * Any other API endpoint, even if its path contains or ends with "login" (e.g.,
         https://controller.com/api/user/login-history), will have the CSRF token added (provided
         avisess.csrfToken is not empty), as these endpoints are likely part of the authenticated
         session and require the token.

  This modification makes the CSRF token handling more accurate and prevents unintended exclusion of
  valid API calls.


Testing done by running all the avisession related test cases.
Tested the fix on GSLB setup as well by @arihantg 