### PR TITLE
AV-253959 Fix: Prevent double-reading of HTTP response body

### DIFF
--- a/go/session/avisession.go
+++ b/go/session/avisession.go
@@ -1760,6 +1760,10 @@ func (avisess *AviSession) extractErrorMessage(resp *http.Response) *string {
 		return nil
 	}
 
+	resp.Body.Close()
+	// After reading, we need to restore the body so it can be read again.
+	resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
 	if len(bodyBytes) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Added fix to print controller returned error message.

```
I1222 12:50:44.950624  398527 avisession.go:993] Error code 400 parsed resp: map[error:Receive timeout of Monitor Test-Hm cannot be more than Send interval] err <nil>

 Healthmonitor creation failed:  Encountered an error on POST request to URL https://100.65.8.114/api/healthmonitor: HTTP code: 400; error from Controller: map[error:Receive timeout of Monitor Test-Hm cannot be more than Send interval]

```