### PR TITLE
AV-284569: Upgraded java version in  java sdk from java 8 to 17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
           server-id: central
@@ -52,7 +52,9 @@ jobs:
         id: get_sdk_version
         run: | 
           echo "::set-output name=AVI_VERSION::$(python ./python/version.py)"
+          echo "GITHUB_REF: $GITHUB_REF"
           JAVA_VERSION=$(echo ${GITHUB_REF##*/} | cut -d - -f 2)
+          echo "JAVA_VERSION: $JAVA_VERSION"
           if [[ "$JAVA_VERSION" == *"post"* ]]; then
             echo "Java version post"
             JAVA_VERSION="${JAVA_VERSION/post/\.}"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.vmware.avi.sdk</groupId>
 	<artifactId>avisdk</artifactId>
-	<version>22.1.3</version>
+	<version>32.1.2</version>
 	<name>avisdk</name>
 	<description>Avi SDK is a java API which creates a session with controller and perform CRUD operations.</description>
 	<url>https://github.com/vmware/alb-sdk/tree/master/java</url>
@@ -77,7 +77,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.13.0</version>
 				<configuration>
-					<release>8</release>
+					<release>17</release>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -136,7 +136,7 @@
 		</plugins>
 	</build>
 	<properties>
-		<jackson.version>2.13.4</jackson.version>
+		<jackson.version>2.18.6</jackson.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -155,44 +155,28 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.4.2</version>
+			<version>${jackson.version}</version>
 			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.4</version>
+			<version>3.18.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/javax.validation/validation-api -->
 		<dependency>
-			<groupId>javax.validation</groupId>
-			<artifactId>validation-api</artifactId>
-			<version>2.0.1.Final</version>
-			<scope>provided</scope>
-		</dependency>
-
-
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.2</version>
-			<scope>provided</scope>
-		</dependency>
-
-		<!-- https://mvnrepository.com/artifact/commons-logging/commons-logging -->
-		<dependency>
-			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging</artifactId>
-			<version>1.2</version>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>3.0.2</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpcore -->
 		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpcore</artifactId>
-			<version>4.4.12</version>
+			<groupId>org.apache.httpcomponents.client5</groupId>
+			<artifactId>httpclient5</artifactId>
+			<version>5.4.3</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
@@ -202,10 +186,6 @@
 			<version>${jackson.version}</version>
 			<scope>provided</scope>
 		</dependency>
-		<!-- https://mvnrepository.com/artifact/com.googlecode.json-simple/json-simple -->
-		<!-- <dependency> <groupId>com.googlecode.json-simple</groupId> <artifactId>json-simple</artifactId> 
-			<version>1.1.1</version> </dependency> -->
-		<!-- https://mvnrepository.com/artifact/org.json/json -->
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
@@ -217,7 +197,7 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.13.1</version>
-			<scope>provided</scope>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
@@ -228,14 +208,8 @@
 		<dependency>
 			<groupId>com.github.tomakehurst</groupId>
 			<artifactId>wiremock-jre8</artifactId>
-			<version>2.35.1</version>
+			<version>3.0.1</version>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpmime</artifactId>
-			<version>4.5.14</version>
-			<scope>provided</scope>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations -->
 		<dependency>
@@ -255,7 +229,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>5.3.32</version>
+			<version>6.2.18</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -263,7 +237,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
-			<version>2.5.12</version>
+			<version>3.5.14</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/java/src/com/vmware/avi/sdk/AviApi.java
+++ b/java/src/com/vmware/avi/sdk/AviApi.java
@@ -5,7 +5,6 @@
 package com.vmware.avi.sdk;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,30 +19,28 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.logging.Logger;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.mime.HttpMultipartMode;
-import org.apache.http.entity.mime.MultipartEntityBuilder;
-import org.apache.http.entity.mime.content.FileBody;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.entity.mime.FileBody;
+import org.apache.hc.client5.http.entity.mime.HttpMultipartMode;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
+import org.apache.hc.core5.net.URIBuilder;
+import org.apache.hc.core5.http.HttpEntity;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import com.vmware.avi.sdk.model.AviApiResponse;
 
 /**
  * This class creates a session with controller and facilitates CRUD operations.
@@ -72,7 +69,7 @@ public class AviApi {
 	public AviApi(AviCredentials aviCredentials) {
 		this.aviCredentials = aviCredentials;
 		this.sessionKey = AviRestUtils.getSessionKey(aviCredentials);
-		this.restTemplate = AviRestUtils.getRestTemplate(aviCredentials);
+		this.restClient = AviRestUtils.getRestClient(aviCredentials);
 	}
 
 	/**
@@ -89,7 +86,7 @@ public class AviApi {
 	 */
 	private String sessionKey;
 
-	private RestTemplate restTemplate;
+	private RestClient restClient;
 
 	/**
 	 * This static factory method to create session if not present in the pool if
@@ -133,7 +130,7 @@ public class AviApi {
 		String path = objClass.getSimpleName().toLowerCase();
 		String getUrl = path + "/" + objectUUid;
 
-		T aviObj = (T) this.restTemplate.getForObject(getUrl, objClass);
+		T aviObj = this.restClient.get().uri(getUrl).retrieve().body(objClass);
 		LOGGER.info("__DONE__Executing getForObject is completed..");
 		return aviObj;
 	}
@@ -143,7 +140,7 @@ public class AviApi {
 		String path = objClass.getSimpleName().toLowerCase();
 		String getUrl = buildApiParams(path.split("apiresponse")[0], params);
 
-		T aviObj = (T) this.restTemplate.getForObject(getUrl, objClass, params);
+		T aviObj = this.restClient.get().uri(getUrl).retrieve().body(objClass);
 		LOGGER.info("__DONE__Executing getForObject is completed..");
 		return aviObj;
 	}
@@ -155,9 +152,9 @@ public class AviApi {
 
 		T aviObj = null;
 		if (params != null) {
-			aviObj = (T) this.restTemplate.getForObject(getUrl, objClass, params);
+			aviObj = this.restClient.get().uri(getUrl).retrieve().body(objClass);
 		} else {
-			aviObj = (T) this.restTemplate.getForObject(getUrl, objClass);
+			aviObj = this.restClient.get().uri(getUrl).retrieve().body(objClass);
 		}
 		LOGGER.info("__DONE__Executing getForObjectList is completed..");
 		return aviObj;
@@ -166,7 +163,9 @@ public class AviApi {
 	public String buildApiParams(String path, Map<String, String> params) {
 		LOGGER.info("__INIT__ Inside buildApiParams..");
 		UriComponentsBuilder uriBuilder = UriComponentsBuilder
-				.fromHttpUrl(restTemplate.getUriTemplateHandler().expand("/").toString().concat(path));
+				.fromUriString(AviRestUtils.getControllerURL(this.aviCredentials))
+				.path("/api/")
+				.path(path);
 		if (null != params) {
 			for (String key : params.keySet()) {
 				uriBuilder.queryParam(key, params.get(key));
@@ -197,18 +196,15 @@ public class AviApi {
 			if (params != null) {
 				getUrl = buildApiParams(path, params);
 			}
-			HttpEntity requestEntity = null;
+			RestClient.RequestHeadersSpec<?> requestSpec = this.restClient.get().uri(getUrl);
 			if (userHeaders != null) {
 				HttpHeaders headers = setHeaders(userHeaders);
-				requestEntity = new HttpEntity(headers);
+				requestSpec.headers(h -> h.addAll(headers));
 			}
+			ResponseEntity<String> response = requestSpec.retrieve().toEntity(String.class);
 			if (path.contains("/")) {
-				ResponseEntity<String> response = restTemplate.exchange(getUrl, HttpMethod.GET, requestEntity,
-						String.class);
 				jsonObject = new JSONObject(response.getBody());
 			} else {
-				ResponseEntity<AviApiResponse> response = restTemplate.exchange(getUrl, HttpMethod.GET, requestEntity,
-						AviApiResponse.class);
 				jsonObject = new JSONObject(response.getBody());
 			}
 			LOGGER.info("__DONE__Executing GET is completed..");
@@ -241,35 +237,48 @@ public class AviApi {
 		return this.put(path, body, null);
 	}
 
+	@SuppressWarnings("unchecked")
 	public <T> ResponseEntity<T> put(T aviObj, String objectUUid) throws JSONException, AviApiException, IOException {
 		LOGGER.info("__INIT__ Inside executing PUT..");
 		String path = aviObj.getClass().getSimpleName().toLowerCase();
 		String getUrl = path + "/" + objectUUid;
 
-		HttpEntity<T> requestEntity = new HttpEntity<T>(aviObj);
-		ResponseEntity<T> response = (ResponseEntity<T>) restTemplate.exchange(getUrl, HttpMethod.PUT, requestEntity,
-				aviObj.getClass());
+		ResponseEntity<T> response = (ResponseEntity<T>) restClient.put()
+				.uri(getUrl)
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(aviObj)
+				.retrieve()
+				.toEntity(aviObj.getClass());
 		LOGGER.info("__DONE__Executing PUT is completed..");
 		return response;
 	}
 
+	@SuppressWarnings("unchecked")
 	public <T> ResponseEntity<T> post(T aviObj) throws JSONException, AviApiException, IOException {
 		LOGGER.info("__INIT__ Inside executing POST..");
 		String path = aviObj.getClass().getSimpleName().toLowerCase();
 		String getUrl = path;
-		ResponseEntity<T> responseEntity = (ResponseEntity<T>) this.restTemplate.postForEntity(getUrl, aviObj,
-				aviObj.getClass());
+		ResponseEntity<T> responseEntity = (ResponseEntity<T>) this.restClient.post()
+				.uri(getUrl)
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(aviObj)
+				.retrieve()
+				.toEntity(aviObj.getClass());
 		LOGGER.info("__DONE__Executing POST is completed..");
 		return responseEntity;
 	}
 
+	@SuppressWarnings("unchecked")
 	public <T> ResponseEntity<T> delete(Class<T> objClass, String objUUid)
 			throws JSONException, AviApiException, IOException {
 		LOGGER.info("__INIT__ Inside executing DELETE..");
 		String path = objClass.getSimpleName().toLowerCase();
 		String getUrl = path + "/" + objUUid;
 
-		ResponseEntity<T> responseEntity = restTemplate.exchange(getUrl, HttpMethod.DELETE, null, objClass);
+		ResponseEntity<T> responseEntity = (ResponseEntity<T>) this.restClient.delete()
+				.uri(getUrl)
+				.retrieve()
+				.toEntity(objClass);
 		LOGGER.info("__DONE__Executing DELETE is completed..");
 		return responseEntity;
 	}
@@ -326,15 +335,12 @@ public class AviApi {
 				putUrl = path.toLowerCase().concat("/" + objectUuid);
 			}
 
-			HttpEntity<String> requestEntity;
+			RestClient.RequestBodySpec requestSpec = this.restClient.put().uri(putUrl);
 			if (userHeaders != null) {
 				HttpHeaders headers = setHeaders(userHeaders);
-				requestEntity = new HttpEntity<String>(body.toString(), headers);
-			} else {
-				requestEntity = new HttpEntity<String>(body.toString());
-			}
-			ResponseEntity<String> response = (ResponseEntity<String>) restTemplate.exchange(putUrl, HttpMethod.PUT,
-					requestEntity, String.class);
+				requestSpec.headers(h -> h.addAll(headers));
+			} 
+			ResponseEntity<String> response = requestSpec.body(body.toString()).retrieve().toEntity(String.class);
 
 			JSONObject jsonObject = null;
 			if (response.getBody() != null) {
@@ -390,15 +396,12 @@ public class AviApi {
 		try {
 			LOGGER.info("__INIT__ Inside executing POST..");
 
-			HttpEntity<String> requestEntity;
+			RestClient.RequestBodySpec requestSpec = this.restClient.post().uri(path);
 			if (userHeaders != null) {
 				HttpHeaders headers = setHeaders(userHeaders);
-				requestEntity = new HttpEntity<String>(body.toString(), headers);
-			} else {
-				requestEntity = new HttpEntity<String>(body.toString());
-			}
-			ResponseEntity<String> response = (ResponseEntity<String>) restTemplate.exchange(path, HttpMethod.POST,
-					requestEntity, String.class);
+				requestSpec.headers(h -> h.addAll(headers));
+			} 
+			ResponseEntity<String> response = requestSpec.body(body.toString()).retrieve().toEntity(String.class);
 
 			JSONObject jsonObject = new JSONObject(response.getBody());
 			LOGGER.info("__DONE__Executing POST is completed..");
@@ -466,13 +469,12 @@ public class AviApi {
 	public JSONObject delete(String path, String uuid, HashMap<String, String> userHeaders) throws AviApiException {
 		LOGGER.info("__INIT__ Inside executing DELETE..");
 		String deleteUrl = AviRestUtils.getControllerURL(this.aviCredentials) + "/api/" + path + "/" + uuid;
-		if (userHeaders == null) {
-			this.restTemplate.delete(deleteUrl);
-		} else {
-            HttpHeaders headers = setHeaders(userHeaders);
-			HttpEntity<String> requestEntity = new HttpEntity<String>(headers);
-			this.restTemplate.exchange(deleteUrl, HttpMethod.DELETE, requestEntity, String.class);
-		}
+		RestClient.RequestHeadersSpec<?> requestSpec = this.restClient.delete().uri(deleteUrl);
+		if (userHeaders != null) {
+             HttpHeaders headers = setHeaders(userHeaders);
+             requestSpec.headers(h -> h.addAll(headers));
+        }
+		requestSpec.retrieve().toBodilessEntity();
 		LOGGER.info("__DONE__Executing DELETE is completed..");
 		return new JSONObject();
 	}
@@ -500,14 +502,14 @@ public class AviApi {
 			// This attaches the file to the POST:
 			File f = new File(filePath);
 			FileBody fileBody = new FileBody(f, ContentType.MULTIPART_FORM_DATA);
-			MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create().setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
+			MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create().setMode(HttpMultipartMode.EXTENDED);
 			entityBuilder.addPart("file", fileBody);
 			entityBuilder.setBoundary(boundary);
-			org.apache.http.HttpEntity entity = entityBuilder.build();
+			HttpEntity entity = entityBuilder.build();
 
 			request.setEntity(entity);
 			CloseableHttpResponse response = httpClient.execute(request);
-			int responseCode = response.getStatusLine().getStatusCode();
+			int responseCode = response.getCode();
 			if (responseCode > 299) {
 				StringBuffer errMessage = new StringBuffer();
 				errMessage.append("Failed : HTTP error code : ");
@@ -522,6 +524,10 @@ public class AviApi {
 		} catch (HttpClientErrorException e) {
 			String errorMsg = e.getResponseBodyAsString();
 			LOGGER.severe("Exception in FileUpload : " + errorMsg);
+			throw new AviApiException(errorMsg);
+		} catch(ParseException e){
+			String errorMsg = e.getMessage();
+			LOGGER.severe("ParseException in FileUpload : " + errorMsg);
 			throw new AviApiException(errorMsg);
 		} catch (Exception e) {
 			StringWriter sw = new StringWriter();
@@ -558,7 +564,7 @@ public class AviApi {
 		FileOutputStream fileOutputStream = null;
 		String filePath = null;
 		try {
-			HttpResponse response = null;
+			CloseableHttpResponse response = null;
 			httpClient = AviRestUtils.buildHttpClient(this.aviCredentials);
 			LOGGER.info("Inside download file :: Path is :" + path);
 			String getUrl = AviRestUtils.getControllerURL(this.aviCredentials) + "/api/" + path;

--- a/java/src/com/vmware/avi/sdk/AviRestUtils.java
+++ b/java/src/com/vmware/avi/sdk/AviRestUtils.java
@@ -8,37 +8,45 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.apache.http.Header;
-import org.apache.http.HttpEntityEnclosingRequest;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpResponse;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.HttpRequestRetryHandler;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.conn.ConnectTimeoutException;
-import org.apache.http.conn.HttpHostConnectException;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.DefaultServiceUnavailableRetryStrategy;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.ssl.SSLContexts;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.ConnectTimeoutException;
+import org.apache.hc.client5.http.HttpHostConnectException;
+import org.apache.hc.client5.http.HttpRequestRetryStrategy;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
+import org.apache.hc.client5.http.ssl.TrustSelfSignedStrategy;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.ssl.SSLContexts;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
 import org.json.JSONObject;
-import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 
 import javax.net.ssl.SSLContext;
@@ -47,8 +55,8 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.HttpCookie;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.logging.Logger;
@@ -57,7 +65,7 @@ public class AviRestUtils {
 
 	static final Logger LOGGER = Logger.getLogger(AviRestUtils.class.getName());
 	static final int SOCKET_TIMEOUT = 300000; // 5 Min
-	private static HashMap<String, RestTemplate> sessionPool = new HashMap<String, RestTemplate>();
+	private static HashMap<String, RestClient> sessionPool = new HashMap<String, RestClient>();
 	private static final String API_PREFIX = "/api/";
 
 	public static void clearSession(AviCredentials creds){
@@ -68,52 +76,54 @@ public class AviRestUtils {
 		}
 	}
 
-	public static RestTemplate getRestTemplate(AviCredentials creds) {
-		LOGGER.info("__INIT__ Rest template initialization..");
-		RestTemplate restTemplate = null;
-		if (creds != null) {
-			if (sessionPool.containsKey(getSessionKey(creds))) {
-				return sessionPool.get(getSessionKey(creds));
-			}
-			try {
-				restTemplate = getInitializedRestTemplate(creds);
-				DefaultUriBuilderFactory uriBuilderFactory = new DefaultUriBuilderFactory(getControllerURL(creds) + API_PREFIX);
-				restTemplate.setUriTemplateHandler(uriBuilderFactory);
-				List<ClientHttpRequestInterceptor> interceptors = Collections
-						.<ClientHttpRequestInterceptor>singletonList(new AviAuthorizationInterceptor(creds));
-				restTemplate.setInterceptors(interceptors);
-				restTemplate.setMessageConverters(getMessageConverters(restTemplate));
-				AviRestUtils.sessionPool.put(getSessionKey(creds), restTemplate);
-				LOGGER.info("__DONE__ Rest template initialize.");
-				return restTemplate;
-			} catch (Exception e) {
-				LOGGER.severe("Exception during rest template initialization");
+	public static RestClient getRestClient(AviCredentials creds) {
+        LOGGER.info("__INIT__ Rest client initialization..");
+        RestClient restClient = null;
+        if (creds != null) {
+            if (sessionPool.containsKey(getSessionKey(creds))) {
+                return sessionPool.get(getSessionKey(creds));
+            }
+            try {
+                restClient = getInitializedRestClient(creds);
+                AviRestUtils.sessionPool.put(getSessionKey(creds), restClient);
+                LOGGER.info("__DONE__ Rest client initialize.");
+                return restClient;
+            } catch (Exception e) {
+                LOGGER.severe("Exception during rest client initialization");
 
-			}
-		}
-		return restTemplate;
-	}
+            }
+        }
+        return restClient;
+    }
 
-	private static List<HttpMessageConverter<?>> getMessageConverters(RestTemplate restTemplate) {
+	private static List<HttpMessageConverter<?>> getMessageConverters() {
 		// Get existing message converters
-		List<HttpMessageConverter<?>> messageConverters = restTemplate.getMessageConverters();
-		messageConverters.clear();
-		ObjectMapper objectMapper = new ObjectMapper();
-		objectMapper.setSerializationInclusion(Include.NON_NULL);
-		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-		MappingJackson2HttpMessageConverter mycov = new MappingJackson2HttpMessageConverter(objectMapper);
-		mycov.setPrettyPrint(true);
-		messageConverters.add(new StringHttpMessageConverter());
-		messageConverters.add(mycov);
-		return messageConverters;
+		List<HttpMessageConverter<?>> messageConverters = new ArrayList<>();
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setSerializationInclusion(Include.NON_NULL);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        MappingJackson2HttpMessageConverter mycov = new MappingJackson2HttpMessageConverter(objectMapper);
+        mycov.setPrettyPrint(true);
+        messageConverters.add(new StringHttpMessageConverter());
+        messageConverters.add(mycov);
+        return messageConverters;
 	}
 
-	private static RestTemplate getInitializedRestTemplate(AviCredentials creds) {
+	private static RestClient getInitializedRestClient(AviCredentials creds) {
 		try {
 			CloseableHttpClient client = buildHttpClient(creds);
-			HttpComponentsClientHttpRequestFactory clientHttpRequestFactory = new HttpComponentsClientHttpRequestFactory();
-			clientHttpRequestFactory.setHttpClient(client);
-			return new RestTemplate(clientHttpRequestFactory);
+            HttpComponentsClientHttpRequestFactory clientHttpRequestFactory = new HttpComponentsClientHttpRequestFactory(client);
+            BufferingClientHttpRequestFactory bufferingFactory = new BufferingClientHttpRequestFactory(clientHttpRequestFactory);
+            DefaultUriBuilderFactory uriBuilderFactory = new DefaultUriBuilderFactory(getControllerURL(creds) + API_PREFIX);
+
+            return RestClient.builder()
+                    .requestFactory(bufferingFactory)
+                    .uriBuilderFactory(uriBuilderFactory)
+                    .requestInterceptors(interceptors -> interceptors.add(new AviAuthorizationInterceptor(creds)))
+                    .messageConverters(converters -> {
+                        converters.clear();
+                        converters.addAll(getMessageConverters());
+                    }).build();
 
 		} catch (Exception e) {
 			LOGGER.severe("Exception in creating rest template for AVI connection");
@@ -122,83 +132,128 @@ public class AviRestUtils {
 	}
 
 	/**
-	 * This method sets a custom HttpRequestRetryHandler in order to enable a custom
-	 * exception recovery mechanism.
-	 * 
-	 * @return A HttpRequestRetryHandler representing handling of the retryHandler.
-	 */
-	private static HttpRequestRetryHandler retryHandler(AviCredentials creds) {
-		return (exception, executionCount, context) -> {
-			LOGGER.info("__INIT__ Inside retry_handler..");
-			if (executionCount >= creds.getNumApiRetries()) {
-				// Do not retry if over max retry count
-				return false;
-			}
-			if (exception instanceof InterruptedIOException) {
-				// Timeout
-				return false;
-			}
-			if (exception instanceof UnknownHostException) {
-				// Unknown host
-				return false;
-			}
-			if (exception instanceof SSLException) {
-				// SSL handshake exception
-				return false;
-			}
-			if (exception instanceof HttpHostConnectException) {
-				return true;
-			}
-			HttpClientContext clientContext = HttpClientContext.adapt(context);
-			HttpRequest request = clientContext.getRequest();
-			boolean idempotent = !(request instanceof HttpEntityEnclosingRequest);
-			if (idempotent) {
-				// Retry if the request is considered idempotent
-				return true;
-			}
-			LOGGER.info("__DONE__ Retry handler.");
-			return false;
-		};
-	}
+     * This method sets a custom HttpRequestRetryStrategy in order to enable a custom
+     * exception recovery mechanism.
+     *
+     * @return A HttpRequestRetryStrategy representing handling of the retryHandler.
+     */
+    private static HttpRequestRetryStrategy retryStrategy(AviCredentials creds) {
+        return new HttpRequestRetryStrategy() {
+            @Override
+            public boolean retryRequest(HttpRequest request, IOException exception, int executionCount, HttpContext context) {
+                LOGGER.info("__INIT__ Inside retry_handler.. Current execution count: " + executionCount + " of max: " + creds.getNumApiRetries());
+                if (executionCount >= creds.getNumApiRetries()) {
+                    return false;
+                }
+                if (exception instanceof ConnectTimeoutException) {
+                    // It is a connection timeout, allow it to retry!!
+                    return true;
+                }
+                if (exception instanceof InterruptedIOException) {
+                    // Timeout
+                    return false;
+                }
+                if (exception instanceof UnknownHostException) {
+                    // Unknown host
+                    return false;
+                }
+                if (exception instanceof SSLException) {
+                    // SSL handshake exception
+                    return false;
+                }
+                if (exception instanceof HttpHostConnectException) {
+                    return true;
+                }
+
+                boolean idempotent = Method.isIdempotent(request.getMethod());
+                if (idempotent) {
+                    // Retry if the request is considered idempotent
+                    return true;
+                }
+                LOGGER.info("__DONE__ Retry handler.");
+                return false;
+            }
+
+            @Override
+            public boolean retryRequest(HttpResponse response, int executionCount, HttpContext context) {
+                LOGGER.info("__INIT__ Inside response status retry_handler.. Current execution count: " + executionCount + " of max: "+creds.getNumApiRetries());
+                if (executionCount >= creds.getNumApiRetries()) {
+                    // Do not retry if over max retry count
+                    return false;
+                }
+                return response.getCode() == 503;
+            }
+
+            @Override
+            public TimeValue getRetryInterval(HttpResponse response, int executionCount, HttpContext context) {
+                return TimeValue.ofSeconds(creds.getRetryWaitTime());
+            }
+        };
+    }
 
 	public static CloseableHttpClient buildHttpClient(AviCredentials creds) {
 		LOGGER.info("__INIT__ Inside buildHttpClient..");
 		HttpClientBuilder clientBuilder;
-		if (!creds.getVerify()) {
-			SSLContext sslcontext = null;
-			if (creds.getSslContext() != null){
-				sslcontext = creds.getSslContext();
-			} else {
-				try {
-					sslcontext = SSLContexts.custom().loadTrustMaterial(null, new TrustSelfSignedStrategy()).build();
-				} catch (Exception e) {
-					e.printStackTrace();
-				}
-			}
+		RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectionRequestTimeout(Timeout.ofSeconds(creds.getTimeout()))
+                .setResponseTimeout(Timeout.ofMilliseconds(SOCKET_TIMEOUT))
+                .build();
 
-			SSLConnectionSocketFactory sslConnectionSocketFactory = new SSLConnectionSocketFactory(sslcontext,
-					(s, sslSession) -> true);
-			RequestConfig requestConfig = RequestConfig.custom().
-					setSocketTimeout(SOCKET_TIMEOUT).
-					setConnectionRequestTimeout((creds.getTimeout())*1000).
-					setConnectTimeout((creds.getConnectionTimeout())*1000).
-					build();
+        if (!creds.getVerify()) {
+            SSLContext sslcontext = null;
+            if (creds.getSslContext() != null) {
+                sslcontext = creds.getSslContext();
+            } else {
+                try {
+                    sslcontext = SSLContexts.custom()
+                            .loadTrustMaterial(null, new TrustSelfSignedStrategy()).build();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
 
-			CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-			credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(creds.getUsername(), creds.getPassword()));
+            TlsSocketStrategy tlsStrategy = new DefaultClientTlsStrategy(
+                    sslcontext,
+                    NoopHostnameVerifier.INSTANCE
+            );
+            ConnectionConfig connectionConfig = ConnectionConfig.custom()
+                    .setConnectTimeout(Timeout.ofSeconds(creds.getConnectionTimeout()))
+                    .setSocketTimeout(Timeout.ofMilliseconds(SOCKET_TIMEOUT))
+                    .build();
 
-			clientBuilder = HttpClients.custom().
-					setSSLSocketFactory(sslConnectionSocketFactory).
-					setServiceUnavailableRetryStrategy(new DefaultServiceUnavailableRetryStrategy(creds.getNumApiRetries(),
-							creds.getRetryWaitTime())).
-					disableCookieManagement().setDefaultRequestConfig(requestConfig);
-		} else {
-			clientBuilder = HttpClients.custom().setServiceUnavailableRetryStrategy(
-					new DefaultServiceUnavailableRetryStrategy(creds.getNumApiRetries(), creds.getRetryWaitTime()))
-					.disableCookieManagement();
-		}
+            PoolingHttpClientConnectionManager connectionManager = PoolingHttpClientConnectionManagerBuilder.create()
+                    .setTlsSocketStrategy(tlsStrategy)
+                    .setDefaultConnectionConfig(connectionConfig)
+                    .build();
 
-		clientBuilder.setRetryHandler(retryHandler(creds));
+            BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            char[] passwordChars = (creds.getPassword() != null) ? creds.getPassword().toCharArray() : new char[0];
+            credentialsProvider.setCredentials
+                    (new AuthScope(null, -1),
+                            new UsernamePasswordCredentials(creds.getUsername(), passwordChars));
+
+            clientBuilder = HttpClients.custom()
+                    .setConnectionManager(connectionManager)
+                    .setDefaultCredentialsProvider(credentialsProvider)
+                    .disableCookieManagement()
+                    .setDefaultRequestConfig(requestConfig);
+        } else {
+            ConnectionConfig connectionConfig = ConnectionConfig.custom()
+                    .setConnectTimeout(Timeout.ofSeconds(creds.getConnectionTimeout()))
+                    .setSocketTimeout(Timeout.ofMilliseconds(SOCKET_TIMEOUT))
+                    .build();
+
+            PoolingHttpClientConnectionManager connectionManager = PoolingHttpClientConnectionManagerBuilder.create()
+                    .setDefaultConnectionConfig(connectionConfig)
+                    .build();
+
+            clientBuilder = HttpClients.custom()
+                    .setConnectionManager(connectionManager)
+                    .disableCookieManagement()
+                    .setDefaultRequestConfig(requestConfig);
+        }
+
+        clientBuilder.setRetryStrategy(retryStrategy(creds));
 		LOGGER.info("__DONE__ BuildHttpClient completed");
 		return clientBuilder.build();
 	}
@@ -220,38 +275,43 @@ public class AviRestUtils {
 		try {
 			String postUrl = getControllerURL(aviCredentials) + "/login";
 			HttpPost postRequest = new HttpPost(postUrl);
-			StringEntity input = new StringEntity(body.toString());
-			input.setContentType("application/json");
+			StringEntity input = new StringEntity(body.toString(),ContentType.APPLICATION_JSON);
 			postRequest.addHeader("X-Avi-Version", aviCredentials.getVersion());
 			postRequest.addHeader("X-Avi-Tenant", aviCredentials.getTenant());
 			postRequest.setEntity(input);
-			HttpResponse response = httpClient.execute(postRequest);
-			int statusCode = response.getStatusLine().getStatusCode();
-			if (statusCode > 299) {
-				LOGGER.severe("Login faild with status code " + statusCode);
-				throw new IOException("Failed : HTTP error code : " + response.getStatusLine().getStatusCode());
-			}
-			String output = EntityUtils.toString(response.getEntity());
-			JSONObject result = new JSONObject(output);
-			String sessionCookieName = result.get("session_cookie_name").toString();
-			String csrftoken = null;
-			String sessionCookie = null;
-			for (Header header : response.getHeaders("Set-Cookie")) {
-				List<HttpCookie> httpCookies = HttpCookie.parse(header.getValue());
-				for (HttpCookie cookie : httpCookies) {
-					if (cookie.getName().equals("csrftoken")) {
-						csrftoken = cookie.getValue();
-					} else if (cookie.getName().equals(sessionCookieName)) {
-						sessionCookie = cookie.getValue();
+			CloseableHttpResponse response = httpClient.execute(postRequest);
+			try {
+				int statusCode = response.getCode();
+				if (statusCode > 299) {
+					LOGGER.severe("Login faild with status code " + statusCode);
+					throw new IOException("Failed : HTTP error code : " + response.getCode());
+				}
+				String output = EntityUtils.toString(response.getEntity());
+				JSONObject result = new JSONObject(output);
+				String sessionCookieName = result.get("session_cookie_name").toString();
+				String csrftoken = null;
+				String sessionCookie = null;
+				for (Header header : response.getHeaders("Set-Cookie")) {
+					List<HttpCookie> httpCookies = HttpCookie.parse(header.getValue());
+					for (HttpCookie cookie : httpCookies) {
+						if (cookie.getName().equals("csrftoken")) {
+							csrftoken = cookie.getValue();
+						} else if (cookie.getName().equals(sessionCookieName)) {
+							sessionCookie = cookie.getValue();
+						}
 					}
 				}
+				aviCredentials.setCsrftoken(csrftoken);
+				aviCredentials.setSessionID(sessionCookie);
+				LOGGER.info("__DONE__ Authentication session success for:: " + aviCredentials.getUsername());
+			} finally {
+				response.close();
 			}
-			aviCredentials.setCsrftoken(csrftoken);
-			aviCredentials.setSessionID(sessionCookie);
-			LOGGER.info("__DONE__ Authentication session success for:: " + aviCredentials.getUsername());
 		} catch (ConnectTimeoutException e){
 			throw e;
-		} catch (Exception e) {
+		} catch (ParseException e) {
+            throw new IOException("Failed to parse response: " + e.getMessage(), e);
+        } catch (Exception e) {
 			e.printStackTrace();
             throw e;
 		} finally {
@@ -317,10 +377,10 @@ public class AviRestUtils {
 	/**
 	 * This method sets all HTTP request headers.
 	 * 
-	 * @param request A HttpRequestBase containing all require headers.
+	 * @param request A ClassicHttpRequest containing all require headers.
 	 * @throws Exception
 	 */
-	public static void buildHeaders(HttpRequestBase request, HashMap<String, String> userHeaders,
+	public static void buildHeaders(ClassicHttpRequest request, HashMap<String, String> userHeaders,
 			AviCredentials aviCredentials) throws Exception {
 		LOGGER.info("__INIT__ Inside buildHeaders..");
 		if (null == aviCredentials.getSessionID() || aviCredentials.getSessionID().isEmpty()) {

--- a/java/test/com/vmware/avi/sdk/AviSDKMockTest.java
+++ b/java/test/com/vmware/avi/sdk/AviSDKMockTest.java
@@ -38,20 +38,22 @@ import java.util.List;
 import java.util.Scanner;
 import java.util.logging.Logger;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.entity.mime.MultipartEntityBuilder;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.ClientProtocolException;
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Rule;
@@ -72,14 +74,14 @@ public class AviSDKMockTest {
 	@Rule
 	public WireMockRule wireMockRule = new WireMockRule(8090);
 
-	private HttpResponse httpGetCall() throws IOException {
+	private CloseableHttpResponse httpGetCall() throws IOException {
 		CloseableHttpClient httpClient = HttpClients.createDefault();
 		HttpGet request = new HttpGet("http://localhost:8090/api/pool/pool-0a70a98c-0b7b-4f32-9c93-13a74fcf8201");
 		request.addHeader("Accept", "text/html");
 		return httpClient.execute(request);
 	}
 
-	private HttpResponse httpPostCall() throws IOException {
+	private CloseableHttpResponse httpPostCall() throws IOException {
 		String content = readFile("InputFile.json", StandardCharsets.UTF_8);
 		JSONObject obj = new JSONObject(content);
 		JSONObject postInput = (JSONObject) obj.get("postInput");
@@ -106,23 +108,22 @@ public class AviSDKMockTest {
 
 		CloseableHttpClient httpClient = HttpClients.createDefault();
 		HttpPost request = new HttpPost("http://localhost:8090/api/login");
-		StringEntity input = new StringEntity(body.toString());
-		input.setContentType("application/json");
+		StringEntity input = new StringEntity(body.toString(),ContentType.APPLICATION_JSON);
 		request.addHeader("X-Avi-Version", avicredentials.getVersion());
 		request.addHeader("X-Avi-Tenant", avicredentials.getTenant());
 		request.setEntity(input);
-		HttpResponse response = httpClient.execute(request);
+		CloseableHttpResponse response = httpClient.execute(request);
 		verify(postRequestedFor(urlPathEqualTo("/api/login")));
-		int statusCode = response.getStatusLine().getStatusCode();
+		int statusCode = response.getCode();
 		if (statusCode > 299) {
 			LOGGER.severe("Login faild with status code " + statusCode);
-			throw new IOException("Failed : HTTP error code : " + response.getStatusLine().getStatusCode());
+			throw new IOException("Failed : HTTP error code : " + response.getCode());
 		}
 	}
 
 	@Test
 	public void testPostCall200()
-			throws ClientProtocolException, IOException, NoSuchMethodException, SecurityException, AviApiException {
+			throws ClientProtocolException, IOException, NoSuchMethodException, SecurityException, AviApiException, ParseException {
 		String content = readFile("InputFile.json", StandardCharsets.UTF_8);
 		JSONObject obj = new JSONObject(content);
 		JSONObject postInput = (JSONObject) obj.get("postInput");
@@ -131,9 +132,9 @@ public class AviSDKMockTest {
 				.withRequestBody(containing(poolstr))
 				.willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")));
 
-		HttpResponse httpResponse = httpPostCall();
+		CloseableHttpResponse httpResponse = httpPostCall();
 		verify(postRequestedFor(urlEqualTo("/api/pool")).withHeader("Content-Type", equalTo("application/json")));
-		int responseCode = httpResponse.getStatusLine().getStatusCode();
+		int responseCode = httpResponse.getCode();
 		if (responseCode > 299) {
 			StringBuffer errMessage = new StringBuffer();
 			errMessage.append("Failed : HTTP error code : ");
@@ -158,23 +159,23 @@ public class AviSDKMockTest {
 		stubFor(post(urlEqualTo("/api/pool")).withHeader("Content-Type", equalTo("application/json"))
 				.withRequestBody(containing(poolstr)).willReturn(aResponse().withStatus(503)
 						.withHeader("Content-Type", "application/json").withBody("Service Unavailable")));
-		HttpResponse httpResponse = httpPostCall();
+		CloseableHttpResponse httpResponse = httpPostCall();
 		String stringResponse = convertHttpResponseToString(httpResponse);
 		verify(postRequestedFor(urlEqualTo("/api/pool")).withHeader("Content-Type", equalTo("application/json")));
-		assertEquals(503, httpResponse.getStatusLine().getStatusCode());
+		assertEquals(503, httpResponse.getCode());
 		assertEquals("Service Unavailable", stringResponse);
 
 	}
 
 	@Test
-	public void testGetCall200() throws ClientProtocolException, IOException, AviApiException {
+	public void testGetCall200() throws ClientProtocolException, IOException, AviApiException, ParseException {
 		stubFor(get(urlPathMatching("/api/pool/([a-z0-9-]*)"))
 				.willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")));
 
-		HttpResponse httpResponse = httpGetCall();
+		CloseableHttpResponse httpResponse = httpGetCall();
 		verify(getRequestedFor(urlPathMatching("/api/pool/pool-0a70a98c-0b7b-4f32-9c93-13a74fcf8201")));
 		assertEquals("application/json", httpResponse.getFirstHeader("Content-Type").getValue());
-		int responseCode = httpResponse.getStatusLine().getStatusCode();
+		int responseCode = httpResponse.getCode();
 		if (responseCode > 299) {
 			StringBuffer errMessage = new StringBuffer();
 			errMessage.append("Failed : HTTP error code : ");
@@ -193,10 +194,10 @@ public class AviSDKMockTest {
 		stubFor(get(urlPathMatching("/api/pool/([a-z0-9-]*)")).withHeader("Accept", matching("text/.*")).willReturn(
 				aResponse().withStatus(503).withHeader("Content-Type", "text/html").withBody("Service Unavailable")));
 
-		HttpResponse httpResponse = httpGetCall();
+		CloseableHttpResponse httpResponse = httpGetCall();
 		String stringResponse = convertHttpResponseToString(httpResponse);
 		verify(getRequestedFor(urlPathMatching("/api/pool/pool-0a70a98c-0b7b-4f32-9c93-13a74fcf8201")));
-		assertEquals(503, httpResponse.getStatusLine().getStatusCode());
+		assertEquals(503, httpResponse.getCode());
 		assertEquals("text/html", httpResponse.getFirstHeader("Content-Type").getValue());
 		assertEquals("Service Unavailable", stringResponse);
 
@@ -204,7 +205,7 @@ public class AviSDKMockTest {
 
 	@Test
 	public void testPutCall()
-			throws ClientProtocolException, IOException, NoSuchMethodException, SecurityException, AviApiException {
+			throws ClientProtocolException, IOException, NoSuchMethodException, SecurityException, AviApiException, ParseException {
 		String content = readFile("InputFile.json", StandardCharsets.UTF_8);
 		JSONObject obj = new JSONObject(content);
 		JSONObject postInput = (JSONObject) obj.get("postInput");
@@ -219,9 +220,9 @@ public class AviSDKMockTest {
 		HttpPut request = new HttpPut("http://localhost:8090/api/pool");
 		request.addHeader("Content-Type", "application/json");
 		request.setEntity(entity);
-		HttpResponse httpResponse = httpClient.execute(request);
+		CloseableHttpResponse httpResponse = httpClient.execute(request);
 		verify(putRequestedFor(urlEqualTo("/api/pool")).withHeader("Content-Type", equalTo("application/json")));
-		int responseCode = httpResponse.getStatusLine().getStatusCode();
+		int responseCode = httpResponse.getCode();
 		if (responseCode > 299) {
 			StringBuffer errMessage = new StringBuffer();
 			errMessage.append("Failed : HTTP error code : ");
@@ -237,15 +238,15 @@ public class AviSDKMockTest {
 
 	@Test
 	public void testDeleteCall()
-			throws ClientProtocolException, IOException, NoSuchMethodException, SecurityException, AviApiException {
+			throws ClientProtocolException, IOException, NoSuchMethodException, SecurityException, AviApiException, ParseException {
 		stubFor(delete(urlPathMatching("/api/pool/([a-z0-9-]*)")).willReturn(ok().withStatus(204)));
 
 		CloseableHttpClient httpClient = HttpClients.createDefault();
 		HttpDelete request = new HttpDelete("http://localhost:8090/api/pool/pool-0a70a98c-0b7b-4f32-9c93-13a74fcf8201");
 		request.addHeader("Content-Type", "application/json");
-		HttpResponse httpResponse = httpClient.execute(request);
+		CloseableHttpResponse httpResponse = httpClient.execute(request);
 		verify(deleteRequestedFor(urlPathMatching("/api/pool/pool-0a70a98c-0b7b-4f32-9c93-13a74fcf8201")));
-		int responseCode = httpResponse.getStatusLine().getStatusCode();
+		int responseCode = httpResponse.getCode();
 		if (responseCode > 299) {
 			StringBuffer errMessage = new StringBuffer();
 			errMessage.append("Failed : HTTP error code : ");
@@ -259,7 +260,7 @@ public class AviSDKMockTest {
 	}
 
 	@Test
-	public void testPostFileUpload() throws org.apache.http.ParseException, IOException, AviApiException {
+	public void testPostFileUpload() throws ParseException, IOException, AviApiException {
 		File f = new File("/mnt/files/hsmpackages/safenet.tar");
 		CloseableHttpClient httpClient = HttpClients.createDefault();
 
@@ -268,15 +269,15 @@ public class AviSDKMockTest {
 				.withMultipartRequestBody(aMultipart().withName("file").withBody(binaryEqualTo(f.getName().getBytes())))
 				.willReturn(ok()));
 
-		HttpUriRequest request = RequestBuilder
+		ClassicHttpRequest request = ClassicRequestBuilder
 				.post("http://localhost:8090/api/fileservice/hsmpackages?hsmtype=safenet")
 				.setEntity(MultipartEntityBuilder.create()
 						.addTextBody("uri", "controller://hsmpackages", ContentType.TEXT_PLAIN)
 						.addBinaryBody("file", f.getName().getBytes()).build())
 				.build();
-		HttpResponse response = httpClient.execute(request);
+		CloseableHttpResponse response = httpClient.execute(request);
 		verify(postRequestedFor(urlEqualTo("/api/fileservice/hsmpackages?hsmtype=safenet")));
-		int responseCode = response.getStatusLine().getStatusCode();
+		int responseCode = response.getCode();
 		if (responseCode > 299) {
 			StringBuffer errMessage = new StringBuffer();
 			errMessage.append("Failed : HTTP error code : ");
@@ -289,7 +290,7 @@ public class AviSDKMockTest {
 		}
 	}
 
-	private String convertHttpResponseToString(HttpResponse httpResponse) throws IOException {
+	private String convertHttpResponseToString(CloseableHttpResponse httpResponse) throws IOException {
 		InputStream inputStream = httpResponse.getEntity().getContent();
 		return convertInputStreamToString(inputStream);
 	}


### PR DESCRIPTION
**Changes done**
 - Upgraded java sdk target runtime and compiler settings from `Java 8` to `Java 17`.
 - Upgraded legacy `httpClient` to `httpClient5`.
 - Replaced legacy `restTemplate` with `restClient`
 
**Testing done**
 - Successfully built the sdk locally under `Java 17`.
 - Successfully run and passed all test cases.
 - Successfully passed a full object lifecycle test by utilizing the ResponseEntity structure for the POST, PUT, DELETE   and GET operation call.